### PR TITLE
Ensure libnvonnxparser_plugin is always static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ if(NOT "${CUDA_NVCC_FLAGS}" MATCHES "-std=c\\+\\+11" )
 endif()
 list(APPEND CUDA_NVCC_FLAGS "-Xcompiler -fPIC --expt-extended-lambda")
 CUDA_INCLUDE_DIRECTORIES(${CUDNN_INCLUDE_DIR} ${TENSORRT_INCLUDE_DIR})
-CUDA_ADD_LIBRARY(nvonnxparser_plugin ${PLUGIN_SOURCES})
+CUDA_ADD_LIBRARY(nvonnxparser_plugin STATIC ${PLUGIN_SOURCES})
 target_include_directories(nvonnxparser_plugin PUBLIC ${CUDA_INCLUDE_DIRS} ${ONNX_INCLUDE_DIRS} ${TENSORRT_INCLUDE_DIR} ${CUDNN_INCLUDE_DIR})
 target_link_libraries(nvonnxparser_plugin ${TENSORRT_LIBRARY})
 


### PR DESCRIPTION
- Fixes issue where C2 unintentionally builds this as a shared lib
  and then can't find it at runtime.