### PR TITLE
upgrade onnx version from 8bcecad to dee6d89 (same as pytorch version…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,13 @@ RUN cd /usr/local/src && \
 RUN cd /usr/local/src && \
     git clone --recurse-submodules https://github.com/onnx/onnx.git && \
     cd onnx && \
-    git checkout 8bcecad && \
+    git checkout dee6d89 && \
+    pip2 install  pybind11 && \ 
+    pip2 install  protobuf && \ 
+    pip2 install numpy && \
     python setup.py build && \
     python setup.py install && \
-    cd ../ && \
-    rm -rf onnx/
+    cd ../ 
 
 RUN pip2 install numpy && \
     pip3 install numpy
@@ -57,7 +59,7 @@ RUN tar -xvf TensorRT-${TENSORRT_VERSION}.*.tar.gz && \
     mkdir /usr/share/doc/tensorrt && \
     cp -r doc/* /usr/share/doc/tensorrt/ && \
     mkdir /usr/src/tensorrt && \
-    cp -r samples /usr/src/tensorrt/ && \
+    cp -r samples /usr/src/tensorrt/  && \
     pip2 install python/tensorrt-${TENSORRT_VERSION}.*-cp27-cp27mu-linux_x86_64.whl && \
     pip3 install python/tensorrt-${TENSORRT_VERSION}.*-cp35-cp35m-linux_x86_64.whl && \
     pip2 install uff/uff-*-py2.py3-none-any.whl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,11 @@ RUN cd /usr/local/src && \
     pip2 install  pybind11 && \ 
     pip2 install  protobuf && \ 
     pip2 install numpy && \
+    pip3 install numpy && \
     python setup.py build && \
     python setup.py install && \
-    cd ../ 
-
-RUN pip2 install numpy && \
-    pip3 install numpy
+    cd ../ && \
+    rm -rf onnx/ 
 
 # Install TensorRT
 WORKDIR /usr/local/src

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,5 @@ setup(name='onnx_tensorrt',
       ext_modules=[nv_onnx_parser_module, nv_onnx_runtime_module],
       install_requires=[
           "numpy>=1.8.1",
-          "tensorrt>=3.0.0",
-          "onnx==1.0.1"
+          "onnx>=1.0.1"
       ])


### PR DESCRIPTION
…). otherwise pytorch exported onnx file cannot be consumed by onnx-tensorrt if it has batchnormalization block. There is an error message 3rd input should have consumed marked

 
comment from @bddppq 
https://github.com/pytorch/pytorch/issues/6300
This is a recent change in onnx onnx/onnx@f4acf28 that removed the in-place annotations in onnx level. This change is not included in our last onnx release but we have made the corresponding change to pytorch master to pair with onnx master. So If you can install onnx from the onnx master, this issue should be solved.
