### PR TITLE
Fix some issues with plugin type serialization

### DIFF
--- a/onnx2trt_common.hpp
+++ b/onnx2trt_common.hpp
@@ -62,9 +62,9 @@ namespace nvinfer1 {
 namespace onnx2trt {
 
 struct IOwnable {
-  virtual void destroy();
+  virtual void destroy() = 0;
 protected:
-  virtual ~IOwnable();
+  virtual ~IOwnable() {}
 };
 
 struct OwnableDeleter {

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -26,18 +26,10 @@
 
 namespace onnx2trt {
 
-  void IOwnable::destroy() {
-    delete this;
-  }
-  IOwnable::~IOwnable() {
-  }
-
 // ========================= Plugin =====================
 
   void Plugin::serializeBase(void*& buffer)  {
     const char* plugin_type = getPluginType();
-    serialize_value(&buffer, (const char*)REGISTERABLE_PLUGIN_MAGIC_STRING);
-    serialize_value(&buffer, plugin_type);
     serialize_value(&buffer, _input_dims);
     serialize_value(&buffer, _max_batch_size);
     serialize_value(&buffer, _data_type);
@@ -53,9 +45,7 @@ namespace onnx2trt {
 
   size_t Plugin::getBaseSerializationSize()  {
     const char* plugin_type = getPluginType();
-    return (sizeof(REGISTERABLE_PLUGIN_MAGIC_STRING) + 1 +
-            strlen(plugin_type) +
-            serialized_size(_input_dims) +
+    return (serialized_size(_input_dims) +
             serialized_size(_max_batch_size) +
             serialized_size(_data_type) +
             serialized_size(_data_format));
@@ -76,9 +66,6 @@ namespace onnx2trt {
     _data_format = format;
     _input_dims.assign(inputDims, inputDims + nbInputs);
     _max_batch_size = maxBatchSize;
-  }
-
-  Plugin::~Plugin() {
   }
 
 // ========================= PluginAdapter =====================


### PR DESCRIPTION
- Fixes bug where NvPlugin plugins are not correctly serialized and
  cause a crash during deserialization.
- Serialization of the plugin type string is now done in an adapter
  instead of a base class, which allows it to be used by the NvPlugin
  adapter.
- Also cleans up a few minor things related to the plugin class
  hierarchy.