### PR TITLE
Add info about -v flag support in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ All tests:
 
     python onnx_backend_test.py
 
+You can use `-v` flag to make output more verbose.
+
 ## Pre-trained models
 
 Pre-trained Caffe2 models in ONNX format can be found at https://github.com/onnx/models


### PR DESCRIPTION
This is a kinda hidden feature, but when you do that it displays tests names as they're being done instead of only at the end [so if segfault occurs you know which test caused it].