### PR TITLE
Refactor + improve handling of elwise broadcasting

### DIFF
--- a/TensorOrWeights.hpp
+++ b/TensorOrWeights.hpp
@@ -65,6 +65,10 @@ public:
   inline operator bool() const {
     return this->is_tensor() ? (bool)_tensor : (bool)_weights;
   }
+  nvinfer1::ITensor* reset_tensor(nvinfer1::ITensor* tensor) {
+    assert(this->is_tensor());
+    return _tensor = tensor;
+  }
 };
 
 } // namespace onnx2trt


### PR DESCRIPTION
- Refactors Add/Mul/Pow implementations into importScaleOp function.
- Changes all elementwise ops to use ElementWise + Constant layers
  instead of Scale layer when building against TensorRT >= 4.
  This improves support for broadcasting across any set of dimensions.
- Adds explicit handling of binary op broadcasting semantics for ONNX
  opset < 7 (aka 'legacy broadcasting').