### PR TITLE
Revert "Fix compilation with TensorRT 5 RC (#55)"

### DIFF
--- a/FancyActivation.hpp
+++ b/FancyActivation.hpp
@@ -75,9 +75,6 @@ public:
   FancyActivationPlugin(void const* serialData, size_t serialLength) {
     this->deserialize(serialData, serialLength);
   }
-  FancyActivationPlugin* clone() const override {
-    return new FancyActivationPlugin(_activation_type, _alpha, _gamma);
-  }
   virtual const char* getPluginType() const override { return "FancyActivation"; }
   virtual int getNbOutputs() const override { return 1; }
   virtual nvinfer1::Dims getOutputDimensions(int index,

--- a/InstanceNormalization.hpp
+++ b/InstanceNormalization.hpp
@@ -67,17 +67,6 @@ public:
   InstanceNormalizationPlugin(void const* serialData, size_t serialLength) : _initialized(false) {
     this->deserialize(serialData, serialLength);
   }
-  InstanceNormalizationPlugin* clone() const override {
-    nvinfer1::Weights scale;
-    scale.type = nvinfer1::DataType::kFLOAT;
-    scale.count = _h_scale.size();
-    scale.values = _h_scale.data();
-    nvinfer1::Weights bias;
-    bias.type = nvinfer1::DataType::kFLOAT;
-    bias.count = _h_bias.size();
-    bias.values = _h_bias.data();
-    return new InstanceNormalizationPlugin(_epsilon, scale, bias);
-  }
   const char* getPluginType() const override { return "InstanceNormalization"; }
   bool supportsFormat(nvinfer1::DataType type,
                       nvinfer1::PluginFormat format) const override;

--- a/ResizeNearest.hpp
+++ b/ResizeNearest.hpp
@@ -54,10 +54,6 @@ public:
   ResizeNearestPlugin(void const* serialData, size_t serialLength) {
     this->deserialize(serialData, serialLength);
   }
-  ResizeNearestPlugin* clone() const override {
-    std::vector<float> scale(_scale, _scale + _ndims);
-    return new ResizeNearestPlugin(scale);
-  }
   virtual const char* getPluginType() const override { return "ResizeNearest"; }
   virtual int getNbOutputs() const override { return 1; }
   virtual nvinfer1::Dims getOutputDimensions(int index,

--- a/Split.hpp
+++ b/Split.hpp
@@ -58,9 +58,6 @@ public:
   SplitPlugin(void const* serialData, size_t serialLength) {
     this->deserialize(serialData, serialLength);
   }
-  SplitPlugin* clone() const override {
-    return new SplitPlugin(_axis, _output_lengths);
-  }
   virtual const char* getPluginType() const override { return "Split"; }
   virtual int getNbOutputs() const override { return _output_lengths.size(); }
   virtual nvinfer1::Dims getOutputDimensions(int index,

--- a/plugin.hpp
+++ b/plugin.hpp
@@ -39,14 +39,7 @@ namespace onnx2trt {
 // to be identified when deserializing.
 class Plugin : public nvinfer1::IPluginExt, public IOwnable {
 public:
-  // TODO(benbarsdell): Once TRT 4 support is dropped, our handling of plugins
-  // can be simplified by removing things like IOwnable, getPluginType
-  // serialization, PluginFactory etc. that are now built into TRT >=5.
-#if NV_TENSORRT_MAJOR < 5
-  virtual nvinfer1::IPluginExt* clone() const = 0;
   virtual const char* getPluginType() const = 0;
-#endif
-  virtual const char* getPluginVersion() const { return "1"; }
 
   nvinfer1::Dims const&  getInputDims(int index) const { return _input_dims.at(index); }
   size_t                 getMaxBatchSize()       const { return _max_batch_size; }
@@ -86,14 +79,6 @@ protected:
 public:
   PluginAdapter(nvinfer1::IPlugin* plugin) :
     _plugin(plugin), _ext(dynamic_cast<IPluginExt*>(plugin)) {}
-  nvinfer1::IPluginExt* clone() const override {
-#if NV_TENSORRT_MAJOR < 5
-    // Clone is not (and should not be) used prior to TRT 5
-    return nullptr;
-#else
-    return _ext->clone();
-#endif
-  }
   virtual int getNbOutputs() const override;
   virtual nvinfer1::Dims getOutputDimensions(int index,
                                              const nvinfer1::Dims *inputDims,


### PR DESCRIPTION
This reverts commit 07a9e59aaacdc9af799ee553f335baf81dee5bf3.

The TRT 5 GA release is backwards compatible with TRT 4, so this patch
is no longer needed.