### PR TITLE
Update GPU_ARCHS with 75

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ list(APPEND GPU_ARCHS
     53
     61
     70
+    75
     )
 
 set(CUDA_VERBOSE_BUILD ON)


### PR DESCRIPTION
With TRT5 support integrated, I'd propose building with sm_75 by default.