### PR TITLE
Add basic support for data type inputs other than float32

### DIFF
--- a/onnx2trt_utils.hpp
+++ b/onnx2trt_utils.hpp
@@ -79,12 +79,20 @@ namespace onnx2trt {
 
 inline int get_dtype_size(int32_t onnx_dtype) {
   switch( onnx_dtype ) {
-  case ::ONNX_NAMESPACE::TensorProto::FLOAT:   return 4;
-  case ::ONNX_NAMESPACE::TensorProto::INT8:    return 1;
-  case ::ONNX_NAMESPACE::TensorProto::FLOAT16: return 2;
-  case ::ONNX_NAMESPACE::TensorProto::INT32:   return 4;
-  case ::ONNX_NAMESPACE::TensorProto::INT64:   return 8;
-  // TODO: Add remaining ONNX types...
+  case ::ONNX_NAMESPACE::TensorProto::FLOAT16:   return 2;
+  case ::ONNX_NAMESPACE::TensorProto::FLOAT:     return 4;
+  case ::ONNX_NAMESPACE::TensorProto::DOUBLE:    return 8;
+  case ::ONNX_NAMESPACE::TensorProto::COMPLEX64  return 8;
+  case ::ONNX_NAMESPACE::TensorProto::COMPLEX128 return 16;
+  case ::ONNX_NAMESPACE::TensorProto::UINT8:     return 1;
+  case ::ONNX_NAMESPACE::TensorProto::INT8:      return 1;
+  case ::ONNX_NAMESPACE::TensorProto::UINT16:    return 2;
+  case ::ONNX_NAMESPACE::TensorProto::INT16:     return 2;
+  case ::ONNX_NAMESPACE::TensorProto::UINT32:    return 4;
+  case ::ONNX_NAMESPACE::TensorProto::INT32:     return 4;
+  case ::ONNX_NAMESPACE::TensorProto::UINT64:    return 8;
+  case ::ONNX_NAMESPACE::TensorProto::INT64:     return 8;
+  // TODO: Add BOOL if necessary...
     // TODO: Some sort of error handling
   default: return -1;//throw std::invalid_argument("Unsupported TRT data type: " +
                      //                  std::to_string((int)trt_dtype));
@@ -210,16 +218,21 @@ inline bool convert_onnx_weights(::ONNX_NAMESPACE::TensorProto const& onnx_tenso
     data_ptr = (void*)onnx_tensor.raw_data().data();
     nbytes = onnx_tensor.raw_data().size();
   } else if( onnx_tensor.float_data().size() > 0 ) {
-    assert(onnx_tensor.data_type() == ::ONNX_NAMESPACE::TensorProto::FLOAT);
+    assert(dtype == ::ONNX_NAMESPACE::TensorProto::FLOAT);
     data_ptr = (void*)onnx_tensor.float_data().data();
     nbytes = onnx_tensor.float_data().size() * sizeof(float);
   } else if( onnx_tensor.int32_data().size() > 0 ) {
-    // TODO: Need special handling for int8 or float16 stored as int32_data
-    assert(get_dtype_size(dtype) == 4);
+    assert(dtype == ::ONNX_NAMESPACE::TensorProto::INT32 ||
+           dtype == ::ONNX_NAMESPACE::TensorProto::INT16 ||
+	   dtype == ::ONNX_NAMESPACE::TensorProto::INT8 ||
+	   dtype == ::ONNX_NAMESPACE::TensorProto::UINT16 ||
+	   dtype == ::ONNX_NAMESPACE::TensorProto::UINT8 ||
+	   dtype == ::ONNX_NAMESPACE::TensorProto::BOOL ||
+	   dtype == ::ONNX_NAMESPACE::TensorProto::FLOAT16);
     data_ptr = (void*)onnx_tensor.int32_data().data();
     nbytes = onnx_tensor.int32_data().size() * sizeof(int32_t);
   } else if( onnx_tensor.int64_data().size() > 0 ) {
-    assert(onnx_tensor.data_type() == ::ONNX_NAMESPACE::TensorProto::INT64);
+    assert(dtype == ::ONNX_NAMESPACE::TensorProto::INT64);
     data_ptr = (void*)onnx_tensor.int64_data().data();
     nbytes = onnx_tensor.int64_data().size() * sizeof(int64_t);
   } else {


### PR DESCRIPTION
The purpose is just to handle fp16 (and int16, uint16, int8, uint8, bool and int32) inputs.

By default the TRT_engine will still re-cast the weights in FP32, to user FP16 you still need to use `setFp16Mode(true)` on the returned trt_builder to enable FP16.