### PR TITLE
Remove old api_utils reference

### DIFF
--- a/getSupportedAPITest.cpp
+++ b/getSupportedAPITest.cpp
@@ -29,7 +29,6 @@
 #include "NvOnnxParser.h"
 #include "onnx_utils.hpp"
 #include "common.hpp"
-#include "api_utils.h"
 
 
 using std::cout;


### PR DESCRIPTION
Fix a recent build error.  Looks like a refactor missed a reference to a removed header.

Example build error: http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-gpu/detail/PR-13906/4/pipeline