### PR TITLE
Support INT64 types in ShapedWeights

### DIFF
--- a/ShapedWeights.cpp
+++ b/ShapedWeights.cpp
@@ -26,6 +26,23 @@
 
 namespace onnx2trt {
 
+bool convertINT64(void* weightValues, const size_t nbWeights, std::vector<int32_t>& converted_weights)
+{
+  int64_t * weights = static_cast<int64_t *>(weightValues);
+  for (size_t i = 0; i < nbWeights; i++)
+  {
+    if (weights[i] > INT32_MAX || weights[i] < INT32_MIN)
+    {
+      return false;
+    }
+    else
+    {
+      converted_weights[i] = static_cast<int32_t>(weights[i]);
+    }
+  }
+  return true;
+}
+
 size_t ShapedWeights::count() const {
   if( this->shape.nbDims == 0 ) {
     return 0;
@@ -54,15 +71,39 @@ size_t ShapedWeights::size_bytes() const {
 }
 
 ShapedWeights::operator bool() const {
-  return (bool)this->values;
+return (bool)this->values;
 }
 
 ShapedWeights::operator nvinfer1::Weights() const {
   nvinfer1::Weights w;
+  // If INT64 weights, check if all the values can be cast down to INT32.
+  if (this->type == ::ONNX_NAMESPACE::TensorProto::INT64)
+  {
+    cout << "WARNING: Your ONNX model has been generated with INT64 weights, "
+         << "while TensorRT does not natively support INT64. "
+         << "Attempting to cast down to INT32." << endl;
+    std::vector<int32_t> int32_weights;
+    int32_weights.resize(this->count());
+
+    if (!onnx2trt::convertINT64(this->values, this->count(), int32_weights))
+    {
+      cerr << "ERROR: Weights cannot be cast down to INT32." << endl;
+      // Return empty w on failure
+      return w;
+    }
+    else
+    {
+      w.values = static_cast<void*>(int32_weights.data());
+      cout << "Successfully casted down to INT32." << endl;
+    }
+  }
+  else
+  {
+    w.values = this->values;
+  }
   bool supported_type = convert_dtype(this->type, &w.type);
   (void)supported_type;
   assert(supported_type);
-  w.values = this->values;
   w.count = this->count();
   return w;
 }

--- a/ShapedWeights.hpp
+++ b/ShapedWeights.hpp
@@ -46,4 +46,6 @@ bool transposeWeights(ShapedWeights const& weights,
                       nvinfer1::Permutation const& perm,
                       ShapedWeights* result);
 
+bool convertINT64(void * weightValues, const size_t nbWeights, std::vector<int32_t>& converted_weights);
+
 } // namespace onnx2trt

--- a/onnx2trt_utils.hpp
+++ b/onnx2trt_utils.hpp
@@ -127,6 +127,8 @@ inline bool convert_dtype(int32_t onnx_dtype,
   case ::ONNX_NAMESPACE::TensorProto::INT8:    *trt_dtype = nvinfer1::DataType::kINT8;  break;
   case ::ONNX_NAMESPACE::TensorProto::FLOAT16: *trt_dtype = nvinfer1::DataType::kHALF;  break;
 #if NV_TENSORRT_MAJOR >= 4
+  // See ShapedWeights.cpp for sanity check if all values can be safetly downcasted to INT32
+  case ::ONNX_NAMESPACE::TensorProto::INT64:   *trt_dtype = nvinfer1::DataType::kINT32; break;
   case ::ONNX_NAMESPACE::TensorProto::INT32:   *trt_dtype = nvinfer1::DataType::kINT32; break;
 #endif
   default:


### PR DESCRIPTION
Downcast them to INT32 if possible, error out otherwise.