### PR TITLE
Add a missing header file into the installation target list.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(API_TESTS_SOURCES
 
 set(HEADERS
   NvOnnxParser.h
+  NvOnnxParserTypedefs.h
 )
 
 if (NOT TARGET protobuf::libprotobuf)


### PR DESCRIPTION
This is for #193 and based on a conversation in PR #249 . One header file will be added into the target files that should be copied into appropriate directory during installing all components.