### PR TITLE
Support empty weights

### DIFF
--- a/ModelImporter.cpp
+++ b/ModelImporter.cpp
@@ -172,7 +172,8 @@ Status parseGraph(
             auto& output = outputs.at(i);
             ssOutputs << "[" << outputName << " -> " << output.shape() << "], ";
             // Note: This condition is to allow ONNX outputs to be ignored
-            if (output && !outputName.empty())
+            // Always register output weights (even empty ones) as it may be mapped to an unused input
+            if ((output || output.is_weights()) && !outputName.empty())
             {
                 ctx->registerTensor(std::move(output), outputName);
             }


### PR DESCRIPTION
Register all weight outputs as they may be used as an unused optional input for a child node.