### PR TITLE
Fix typo in operators.md supported onnx operators

### DIFF
--- a/operators.md
+++ b/operators.md
@@ -101,7 +101,6 @@ TensorRT supports the following ONNX data types: FLOAT32, FLOAT16, INT8, and BOO
 | QLinearConv           | N          |
 | QLinearMatMul         | N          |
 | QuantizeLinear        | Y          | Scales and zero\-point value must be initializers                                                                                      |
-| RNN                   | N          |
 | RandomNormal          | N          |
 | RandomNormalLike      | N          |
 | RandomUniform         | Y          |


### PR DESCRIPTION
There are two overlapping RNN operators, one supporting and the other not. Since onnx supports RNN, the one with supported N should be removed.

Signed-off-by: juhyung <sonju0427@gmail.com>