### PR TITLE
fix some build warnings/errors on Windows VS2019

### DIFF
--- a/ModelImporter.cpp
+++ b/ModelImporter.cpp
@@ -420,6 +420,22 @@ bool ModelImporter::parseWithWeightDescriptors(void const* serialized_onnx_model
         _errors.push_back(status);
         return false;
     }
+
+    //slx: Do sanity check for shape tensor inputs, make an error here.
+    auto* network = _importer_ctx.network();
+    int numInputs = network->getNbInputs();
+
+    for (int i = 0; i < numInputs; i++)
+    {
+        auto* inputTensor = network->getInput(i);
+        if (inputTensor->isShapeTensor())
+        {
+            auto status = MAKE_INPUT_ERROR("Shape tensor input", ErrorCode::kUNSUPPORTED_NODE, inputTensor->getName());
+            status.setNode(-1);
+            _errors.push_back(status);
+            return false;
+        }
+    }
     return true;
 }
 

--- a/ModelImporter.cpp
+++ b/ModelImporter.cpp
@@ -420,22 +420,6 @@ bool ModelImporter::parseWithWeightDescriptors(void const* serialized_onnx_model
         _errors.push_back(status);
         return false;
     }
-
-    //slx: Do sanity check for shape tensor inputs, make an error here.
-    auto* network = _importer_ctx.network();
-    int numInputs = network->getNbInputs();
-
-    for (int i = 0; i < numInputs; i++)
-    {
-        auto* inputTensor = network->getInput(i);
-        if (inputTensor->isShapeTensor())
-        {
-            auto status = MAKE_INPUT_ERROR("Shape tensor input", ErrorCode::kUNSUPPORTED_NODE, inputTensor->getName());
-            status.setNode(-1);
-            _errors.push_back(status);
-            return false;
-        }
-    }
     return true;
 }
 

--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -1709,9 +1709,9 @@ DEFINE_BUILTIN_OP_IMPORTER(LRN)
     nvinfer1::ITensor& tensor = convertToTensor(inputs.at(0), ctx);
     OnnxAttrs attrs(node, ctx);
     int size = attrs.get<int>("size");
-    float alpha = attrs.get<float>("alpha", 0.0001);
-    float beta = attrs.get<float>("beta", 0.75);
-    float bias = attrs.get<float>("bias", 1.0);
+    float alpha = attrs.get<float>("alpha", 0.0001f);
+    float beta = attrs.get<float>("beta", 0.75f);
+    float bias = attrs.get<float>("bias", 1.0f);
     RETURN_FIRST_OUTPUT(ctx->network()->addLRN(tensor, size, alpha, beta, bias));
 }
 

--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -1019,7 +1019,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Gemm)
         inputASqueezed = squeeze->getOutput(0);
     }
 
-    constexpr auto getMatrixOp = [](const nvinfer1::ITensor& input, bool transpose) {
+    auto getMatrixOp = [](const nvinfer1::ITensor& input, bool transpose) {
         if (input.getDimensions().nbDims == 1)
         {
             return nvinfer1::MatrixOperation::kVECTOR;
@@ -2013,7 +2013,7 @@ DEFINE_BUILTIN_OP_IMPORTER(MatMul)
     ASSERT(inputA->getType() == inputB->getType() && inputA->getType() != nvinfer1::DataType::kINT32, ErrorCode::kUNSUPPORTED_NODE);
     broadcastTensors(ctx, inputA, inputB);
 
-    constexpr auto getMatrixOp = [](const nvinfer1::ITensor& input) {
+    auto getMatrixOp = [](const nvinfer1::ITensor& input) {
         return (input.getDimensions().nbDims == 1) ? nvinfer1::MatrixOperation::kVECTOR
                                                    : nvinfer1::MatrixOperation::kNONE;
     };


### PR DESCRIPTION

We encountered some warnings/errors when building Onnxruntime + TensorRT EP on Windows using Visual Studio 2019.

onnx-tensorrt advertises as a [C++11 project](https://github.com/onnx/onnx-tensorrt/blob/master/CMakeLists.txt#L25) 
so lambdas closure types aren't literals and can't be assigned to constexpr variable.
see https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=vs-2019#lambda-closures
it is allowed in c++17, but not c++14/c++11

also fixed some [C4305 truncation build warnings](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4305?view=vs-2019) 
