### PR TITLE
support align_corners for Resize operator

### DIFF
--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -2471,6 +2471,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Resize)
     }
 
     // Resizes that use scale factors have the same import logic between opsets
+    ASSERT(((transformationMode != "align_corners", "Align_corners should use size information not scale factors!");
     auto scales = ctx->getOpsetVersion() >= 11 ? inputs.at(2) : inputs.at(1);
     ASSERT(scales.is_weights() && "Resize scales must be an initializer!", ErrorCode::kUNSUPPORTED_NODE);
     ShapedWeights scales_weights = scales.weights();
@@ -2485,8 +2486,6 @@ DEFINE_BUILTIN_OP_IMPORTER(Resize)
     }
     layer->setResizeMode(resizeMode);
     layer->setScales(scaleValues, inputRank);
-    if (transformationMode=="align_corners")
-        layer->setAlignCorners(true);
     RETURN_FIRST_OUTPUT(layer);
 }
 

--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -2449,7 +2449,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Resize)
 
     if (ctx->getOpsetVersion() >= 11)
     {
-        ASSERT(((transformationMode == "asymmetric") || (transformationMode == "align_corners")) && "This version of TensorRT only supports asymmetric resize!",
+        ASSERT(((transformationMode == "asymmetric") || (transformationMode == "align_corners")) && "This version of TensorRT only supports asymmetric and align_corners resize!",
             ErrorCode::kUNSUPPORTED_NODE);
         ASSERT(mode != "cubic" && "This version of TensorRT does not support cubic interpolation!",
             ErrorCode::kUNSUPPORTED_NODE);

--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -2471,7 +2471,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Resize)
     }
 
     // Resizes that use scale factors have the same import logic between opsets
-    ASSERT(((transformationMode != "align_corners", "Align_corners should use size information not scale factors!");
+    ASSERT(transformationMode != "align_corners" && "Align_corners should use size information not scale factors!", ErrorCode::kUNSUPPORTED_NODE);
     auto scales = ctx->getOpsetVersion() >= 11 ? inputs.at(2) : inputs.at(1);
     ASSERT(scales.is_weights() && "Resize scales must be an initializer!", ErrorCode::kUNSUPPORTED_NODE);
     ShapedWeights scales_weights = scales.weights();


### PR DESCRIPTION
handle onnx node below

input: "358"
input: "360"
input: "360"
input: "367"
output: "368"
op_type: "Resize"
attribute {
  name: "coordinate_transformation_mode"
  s: "align_corners"
  type: STRING
}
attribute {
  name: "cubic_coeff_a"
  f: -0.75
  type: FLOAT
}
attribute {
  name: "mode"
  s: "linear"
  type: STRING
}
attribute {
  name: "nearest_mode"
  s: "floor"
  type: STRING
}
