### PR TITLE
Add check for shape tensor outputs

### DIFF
--- a/ImporterContext.hpp
+++ b/ImporterContext.hpp
@@ -48,6 +48,7 @@ class ImporterContext final : public IImporterContext
         mTensorNameCounts; // Keep track of how many times a tensor name shows up, to avoid duplicate naming in TRT.
     StringMap<size_t>
         mLayerNameCounts; // Keep track of how many times a tensor name shows up, to avoid duplicate naming in TRT.
+    std::unordered_set<std::string> mUnsupportedShapeTensors; // Container to hold any shape tensors that are the output of layers that do not support shape tensors.
 public:
     ImporterContext(nvinfer1::INetworkDefinition* network, nvinfer1::ILogger* logger)
         : _network(network)
@@ -77,6 +78,10 @@ public:
     virtual StringMap<nvinfer1::DataType>& layerPrecisions() override
     {
         return mLayerPrecisions;
+    }
+    virtual std::unordered_set<std::string>& unsupportedShapeTensors() override
+    {
+        return mUnsupportedShapeTensors;
     }
 
     // This actually handles weights as well, but is named this way to be consistent with the tensors()

--- a/ModelImporter.cpp
+++ b/ModelImporter.cpp
@@ -352,17 +352,25 @@ bool ModelImporter::supportsModel(
         cout << "Failed to sort model topologically, exiting ..." << endl;
         return false;
     }
+
+    auto* ctx = &_importer_ctx;
+
     for (int node_idx : topological_order)
     {
         ::ONNX_NAMESPACE::NodeProto const& node = model.graph().node(node_idx);
+
         // Add the node to the subgraph if:
-        //     1. Importer function is regestiered for the operator type
-        //     2. It is not directly connected to an unsupported input
-        //     3. Parsing did not hit an error on the node
+        //     1. Importer function is registered for the operator type
+        //     2. It is NOT directly connected to an unsupported input
+        //     3. Parsing did NOT hit an error on the node
+        //     4. Any shape tensor output is coming from a supported node
         bool registered = supportsOperator(node.op_type().c_str());
         bool containsInput = (input_node.empty()) ? false : checkForInput(node);
         bool containsIndex = node_idx == error_node;
-        if (registered && !containsInput && !containsIndex)
+        auto const tensor = node.output()[0];
+        bool supportedShapeTensorOutput = ctx->unsupportedShapeTensors().count(tensor) == 0 ? true : false;
+
+        if (registered && !containsInput && !containsIndex && supportedShapeTensorOutput)
         {
             if (newSubGraph)
             {
@@ -447,6 +455,18 @@ void removeShapeTensorCasts(IImporterContext* ctx)
             if (t.getType() != SHAPE_TENSOR_TYPE)
             {
                 t.setType(SHAPE_TENSOR_TYPE);
+            }
+            // Some layers do not support shape tensor outputs. Keep track of these tensor names
+            // for supportsModel().
+            auto type = layer->getType();
+            auto elementwiseOp = layer->getType() == nvinfer1::LayerType::kELEMENTWISE ? (static_cast<nvinfer1::IElementWiseLayer*>(layer))->getOperation() : nvinfer1::ElementWiseOperation::kSUM;
+            auto reduceOp = layer->getType() == nvinfer1::LayerType::kREDUCE ? (static_cast<nvinfer1::IReduceLayer*>(layer))->getOperation() : nvinfer1::ReduceOperation::kSUM;
+
+            if (!supportsShapeTensor(type, elementwiseOp, reduceOp))
+            {
+                auto name = layer->getOutput(0)->getName();
+                ctx->unsupportedShapeTensors().insert(name);
+                LOG_ERROR("Found " << name << " as a shape tensor output from a layer that does not support it!");
             }
         }
     }

--- a/onnx2trt.hpp
+++ b/onnx2trt.hpp
@@ -31,6 +31,7 @@
 #include <functional>
 #include <onnx/onnx_pb.h>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace onnx2trt
@@ -59,6 +60,7 @@ public:
     virtual StringMap<float>& tensorRangeMins() = 0;
     virtual StringMap<float>& tensorRangeMaxes() = 0;
     virtual StringMap<nvinfer1::DataType>& layerPrecisions() = 0;
+    virtual std::unordered_set<std::string>& unsupportedShapeTensors() = 0;
     virtual void registerTensor(TensorOrWeights tensor, const std::string& basename) = 0;
     virtual void registerLayer(nvinfer1::ILayer* layer, const std::string& basename) = 0;
     virtual ShapedWeights createTempWeights(ShapedWeights::DataType type, nvinfer1::Dims shape) = 0;

--- a/onnx2trt_utils.hpp
+++ b/onnx2trt_utils.hpp
@@ -286,6 +286,9 @@ nvinfer1::ITensor* squeezeTensor(IImporterContext* ctx, nvinfer1::ITensor& tenso
 nvinfer1::ITensor* transposeTensor(
     IImporterContext* ctx, nvinfer1::ITensor& tensor, nvinfer1::Permutation const& perm, bool permute_dim_types = true);
 
+// Helper function to filter out shape tensor outputs for layers that do not support it
+bool supportsShapeTensor(nvinfer1::LayerType type, nvinfer1::ElementWiseOperation eleOp, nvinfer1::ReduceOperation redOp);
+
 // Helper function to import ONNX unary ops into TRT
 NodeImportResult unaryHelper(IImporterContext* ctx, TensorOrWeights& input, nvinfer1::UnaryOperation op);
 


### PR DESCRIPTION
* Added mUnsupportedShapeTensors member to ImporterContext to hold shape tensor names of any layer outputs that do not support it.
* Added helper function supportsShapeTensor to hold the list of what layers support and do not support shape tensor outputs. 
* Updated removeShapeTensorCasts function to call supportShapeTensor and populate mUnsupportedShapeTensors during it's initial loop to remove any casts
* Updated supportsModel() to filter out any nodes that have output tensors in mUnsupportedShapeTensors