### PR TITLE
Prefix logging messages with [TRT]

### DIFF
--- a/ModelImporter.cpp
+++ b/ModelImporter.cpp
@@ -374,7 +374,7 @@ bool ModelImporter::supportsModel(
     std::vector<size_t> topological_order;
     if (!toposort(model.graph().node(), &topological_order))
     {
-        cout << "Failed to sort model topologically, exiting ..." << endl;
+        LOG_ERROR("Failed to sort model topologically, exiting ...");
         return false;
     }
 
@@ -408,7 +408,7 @@ bool ModelImporter::supportsModel(
         }
         else
         {
-            std::cout << "Found unsupported node: " << tensorName << std::endl;
+            LOG_WARNING("Found unsupported node: " << tensorName);
             // This is not a supported node, reset newSubGraph
             newSubGraph = true;
             allSupported = false;

--- a/onnx2trt_utils.hpp
+++ b/onnx2trt_utils.hpp
@@ -39,7 +39,7 @@
     do                                                                                                                 \
     {                                                                                                                  \
         std::stringstream ss{};                                                                                        \
-        ss << __FILENAME__ << ":" << __LINE__ << ": " << msg;                                                          \
+        ss << "[TRT]" << __FILENAME__ << ":" << __LINE__ << ": " << msg;                                               \
         ctx->logger().log(severity, ss.str().c_str());                                                                 \
     } while (0)
 


### PR DESCRIPTION
Prefixes all logging messages from the parser with [TRT], and update some std::cout calls to use the logging API.

Signed-off-by: Kevin Chen kevinch@nvidia.com