### PR TITLE
    Fix build on Ubuntu 20.04

### DIFF
--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -3702,7 +3702,7 @@ std::vector<nvinfer1::PluginField> loadFields(string_map<std::vector<uint8_t>>& 
             }
             fields.emplace_back(fieldName.c_str(), data, type, size);
     }
-    return std::move(fields);
+    return fields;
 }
 
 // Any ops that are not supported will attempt to import as plugins.


### PR DESCRIPTION
    Remove std::move in return to resolve this build failure:

    [ 66%] Building CXX object CMakeFiles/onnxruntime_providers.dir/workspace/onnxruntime/onnxruntime/core/providers/cpu/activation/activations.cc.o
    /workspace/onnxruntime/cmake/external/onnx-tensorrt/builtin_op_importers.cpp: In function ‘std::vector<nvinfer1::PluginField> onnx2trt::{anonymous}::loadFields(string_map<std::vector<unsigned char> >&, const OnnxAttrs&, const nvinfer1::PluginFieldCollection*)’:
    /workspace/onnxruntime/cmake/external/onnx-tensorrt/builtin_op_importers.cpp:3737:21: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
     3737 |     return std::move(fields);
          |            ~~~~~~~~~^~~~~~~~
    /workspace/onnxruntime/cmake/external/onnx-tensorrt/builtin_op_importers.cpp:3737:21: note: remove ‘std::move’ call