### PR TITLE
Update common.hpp

### DIFF
--- a/common.hpp
+++ b/common.hpp
@@ -60,7 +60,7 @@ namespace common
     TRT_Logger(Severity verbosity=Severity::kWARNING,
                std::ostream& ostream=std::cout)
       : _verbosity(verbosity), _ostream(&ostream) {}
-    void log(Severity severity, const char* msg) override {
+    void log(Severity severity, const char* msg) noexcept override {
       if( severity <= _verbosity ) {
         time_t rawtime = std::time(0);
         char buf[256];


### PR DESCRIPTION
added noexcept specifier to TRT_Logger::log to avoid looser throw specifier error