### PR TITLE
Cast BOOL concats to INT32

### DIFF
--- a/onnx2trt_utils.cpp
+++ b/onnx2trt_utils.cpp
@@ -152,6 +152,13 @@ bool canUseLinearResize(const size_t scaleSize, const float* scaleFactors)
     return true;
 }
 
+nvinfer1::ITensor* castHelper(IImporterContext* ctx, nvinfer1::ITensor* input, nvinfer1::DataType dtype)
+{
+    nvinfer1::IIdentityLayer* cast = ctx->network()->addIdentity(*input);
+    cast->setOutputType(0, dtype);
+    return cast->getOutput(0);
+}
+
 nvinfer1::ITensor* constantOfShape(IImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node, nvinfer1::ITensor* constant, nvinfer1::ITensor* shape)
 {
     int rank = shape->getDimensions().d[0];

--- a/onnx2trt_utils.hpp
+++ b/onnx2trt_utils.hpp
@@ -154,6 +154,9 @@ Status broadcastTensors(IImporterContext* ctx, nvinfer1::ITensor*& t1, nvinfer1:
 // Helper function to check that linear resize can be used
 bool canUseLinearResize(const size_t scaleSize, const float* scaleFactors);
 
+// Helper function to add a Cast layer in the network
+nvinfer1::ITensor* castHelper(IImporterContext* ctx, nvinfer1::ITensor* input, nvinfer1::DataType dtype);
+
 // Helper function for constantOfShape operator. Input shape must be a shape tensor
 nvinfer1::ITensor* constantOfShape(IImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node, nvinfer1::ITensor* constant, nvinfer1::ITensor* shape);
 


### PR DESCRIPTION
Fixes #534 by casting BOOL tensors in concat nodes to INT32 first, then casting back.

Signed-off-by: Kevin Chen <kevinch@nvidia.com>