### PR TITLE
Update builtin_op_importers.cpp

### DIFF
--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -2615,7 +2615,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Resize)
         //    alignCorners = 1: ASYMMETRIC
         // Linear:
         //    alignCorners = 0: HALF_PIXEL
-        //    alignCorners = 1: ASYMMETRIC
+        //    alignCorners = 1: ALIGN_CORNERS
         else
         {
             if (mode == "nearest")
@@ -2624,8 +2624,8 @@ DEFINE_BUILTIN_OP_IMPORTER(Resize)
             }
             else if (mode == "linear")
             {
-                ASSERT((transformationMode == "asymmetric" || transformationMode == "pytorch_half_pixel" || transformationMode == "half_pixel") && "TensorRT only supports half pixel, pytorch half_pixel, and asymmetric tranformation mode for linear resizes when scales are provided!", ErrorCode::kUNSUPPORTED_NODE);
-                if (transformationMode == "asymmetric")
+                ASSERT((transformationMode == "align_corners" || transformationMode == "pytorch_half_pixel" || transformationMode == "half_pixel") && "TensorRT only supports half pixel, pytorch half_pixel, and asymmetric tranformation mode for linear resizes when scales are provided!", ErrorCode::kUNSUPPORTED_NODE);
+                if (transformationMode == "align_corners")
                 {
                     layer->setAlignCorners(true);
                 }


### PR DESCRIPTION
Pytorch exports linear interpolation with align_corners=True using coordinate_transformation_mode = "align_corners" and not "asymmetric".

See https://github.com/pytorch/pytorch/blob/master/torch/onnx/symbolic_opset11.py line 214-215:
coordinate_transformation_mode = "asymmetric" if interpolate_mode == "nearest" \
            else "align_corners" if align_corners else "pytorch_half_pixel"