### PR TITLE
Mark negative indices support for gather as optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,11 @@ if(BUILD_ONNXIFI)
   set(ONNXIFI_SOURCES onnx_trt_backend.cpp)
 endif()
 
+# Build with negative indices support for Gather:
+if (DEFINED SUPPORT_NEGATIVE_GATHER)
+  add_definitions("-DSUPPORT_NEGATIVE_GATHER=1")
+endif()
+
 # Build executables if BUILD_LIBRARY_ONLY flag is not set
 if (NOT DEFINED BUILD_LIBRARY_ONLY)
   set(EXECUTABLE_SOURCES

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Once you have cloned the repository, you can build the parser libraries and exec
     // Ensure that you update your LD_LIBRARY_PATH to pick up the location of the newly built library:
     export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
 
-For building only the libraries, append `-DBUILD_LIBRARY_ONLY=1` to the CMake build command.
+For building only the libraries, append `-DBUILD_LIBRARY_ONLY=1` to the CMake build command. If your model has Gather or GatherElements operations with negative indices, add `-DSUPPORT_NEGATIVE_GATHER` to the build command. Note that enabling negative-indices gather will have a performance impact on gathers with non-negative indices.
 
 ## Executable Usage
 

--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -1201,8 +1201,11 @@ DEFINE_BUILTIN_OP_IMPORTER(Gather)
     TRT_CHECK(convertAxis(axis, nbDims));
     LOG_VERBOSE("Using Gather axis: " << axis);
 
-    // Convert any negative indices to positive ones
+    // Support for negative indices can be enabled through adding -DSUPPORT_NEGATIVE_GATHER=1 in the CMake build command.
+    // This will unnecessarily reduce performance of networks that use only non-negative Gather indices.
+#if SUPPORT_NEGATIVE_GATHER
     indices = convertGatherIndices(ctx, data, indices, axis);
+#endif // SUPPORT_NEGATIVE_GATHER
 
     auto* layer = ctx->network()->addGather(*data, *indices, axis);
     ctx->registerLayer(layer, getNodeName(node));
@@ -1251,8 +1254,11 @@ DEFINE_BUILTIN_OP_IMPORTER(GatherElements)
     int32_t axis = attrs.get<int32_t>("axis", 0);
     int32_t dataNbDims = daDims.nbDims;
 
-    // Convert any negative indices to positive ones
+    // Support for negative indices can be enabled through adding -DSUPPORT_NEGATIVE_GATHER=1 in the CMake build command.
+    // This will unnecessarily reduce performance of networks that use only non-negative Gather indices.
+#if SUPPORT_NEGATIVE_GATHER
     index = convertGatherIndices(ctx, data, index, axis);
+#endif // SUPPORT_NEGATIVE_GATHER
 
     TRT_CHECK(convertAxis(axis, dataNbDims));
     LOG_VERBOSE("Using Gather axis: " << axis);


### PR DESCRIPTION
* Make the changes introduced in #678 optional with a CMake switch
* Optimize negative indices calculation

Signed-off-by: Kevin Chen <kevinch@nvidia.com>