### PR TITLE
21.05 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For press and other inquiries, please contact Hector Marinez at hmarinez@nvidia.
 
 ## Supported TensorRT Versions
 
-Development on the Master branch is for the latest version of [TensorRT 7.2.2](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
+Development on the Master branch is for the latest version of [TensorRT 7.2.3.4](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
 
 For previous versions of TensorRT, refer to their respective branches.
 
@@ -48,8 +48,8 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 ### Dependencies
 
  - [Protobuf >= 3.0.x](https://github.com/google/protobuf/releases)
- - [TensorRT 7.2.2](https://developer.nvidia.com/tensorrt)
- - [TensorRT 7.2.2 open source libaries (master branch)](https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 7.2.3.4](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 7.2.3.4 open source libaries (master branch)](https://github.com/NVIDIA/TensorRT/)
 
 ### Building
 
@@ -94,7 +94,7 @@ Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` 
 
     python3 -m pip install <tensorrt_install_dir>/python/tensorrt-7.x.x.x-cp<python_ver>-none-linux_x86_64.whl
 
-TensorRT 7.2.2 supports ONNX release 1.6.0. Install it with:
+TensorRT 7.2.3.4 supports ONNX release 1.6.0. Install it with:
 
     python3 -m pip install onnx==1.6.0
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,21 @@
 
 # ONNX-TensorRT Changelog
 
+## 21.05 Container Release - 2021-05-19
+### Added
+- Added support for InstanceNormalization on 5D tensors
+- Added library only build target [#659](https://github.com/onnx/onnx-tensorrt/pull/659)
+- Added support for negative gather indices [#681](https://github.com/onnx/onnx-tensorrt/pull/681)
+- Added support for `DOUBLE`-typed inputs and weights through downcast to float [#674](https://github.com/onnx/onnx-tensorrt/pull/674)
+- Added support for optional plugin fields in FallbackPlugin path [#676](https://github.com/onnx/onnx-tensorrt/pull/676)
+
+### Updated
+- Updated license [#657](https://github.com/onnx/onnx-tensorrt/pull/657)
+
+### Fixes
+- Fixed index offset calculation in GatherElements [#675](https://github.com/onnx/onnx-tensorrt/pull/675)
+- Clarified dynamic shape support for ReverseSequence
+
 ## 21.03 Container Release - 2021-03-09
 ### Added
 - Added opset13 support for `SoftMax`, `LogSoftmax`, `Squeeze`, and `Unsqueeze`
@@ -13,7 +28,7 @@
 
 ## 21.02 Container Release - 2021-01-18
 ### Added
- - Added support for the `ReverseSequence` operator [#590] - https://github.com/onnx/onnx-tensorrt/pull/590
+ - Added support for the `ReverseSequence` operator [#590](https://github.com/onnx/onnx-tensorrt/pull/590)
  - Updated `parse()` and `supportsModel()` API calls with an optional `model_path` parameter to support models with external weights [#621](https://github.com/onnx/onnx-tensorrt/pull/621)
  - Added support for the `Celu` operator
  - Added support for the `CumSum` operator

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -4,7 +4,7 @@
 
 TensorRT 7.2 supports operators up to Opset 13. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md)
 
-TensorRT supports the following ONNX data types: FLOAT32, FLOAT16, INT8, and BOOL
+TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, INT8, and BOOL
 
 > Note: There is limited support for INT32, INT64, and DOUBLE types. TensorRT will attempt to cast down INT64 to INT32 and DOUBLE down to FLOAT where possible. If not possible, TensorRT will throw an error. See the [TensorRT layer support matrix](https://docs.nvidia.com/deeplearning/sdk/tensorrt-support-matrix/index.html#layers-precision-matrix) for more information on data type support.
 


### PR DESCRIPTION
### Added
- Added support for InstanceNormalization on 5D tensors
- Added library only build target [#659](https://github.com/onnx/onnx-tensorrt/pull/659)
- Added support for negative gather indices [#681](https://github.com/onnx/onnx-tensorrt/pull/681)
- Added support for `DOUBLE`-typed inputs and weights through downcast to float [#674](https://github.com/onnx/onnx-tensorrt/pull/674)
- Added support for optional plugin fields in FallbackPlugin path [#676](https://github.com/onnx/onnx-tensorrt/pull/676)

### Updated
- Updated license [#657](https://github.com/onnx/onnx-tensorrt/pull/657)

### Fixes
- Fixed index offset calculation in GatherElements [#675](https://github.com/onnx/onnx-tensorrt/pull/675)
- Clarified dynamic shape support for ReverseSequence


Signed-off-by: Kevin Chen <kevinch@nvidia.com>