### PR TITLE
Fixes for ONNXRT unit tests

### DIFF
--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -1370,7 +1370,7 @@ DEFINE_BUILTIN_OP_IMPORTER(GatherElements)
 
     nvinfer1::ITensor* data = &convertToTensor(inputs.at(0), ctx);
     nvinfer1::ITensor* index = &convertToTensor(inputs.at(1), ctx);
-    ASSERT((data.getType() != nvinfer1::DataType::kBOOL) && "This version of TensorRT does not support BOOL input type for the GatherElements operator.", ErrorCode::kUNSUPPORTED_NODE);
+    ASSERT((data->getType() != nvinfer1::DataType::kBOOL) && "This version of TensorRT does not support BOOL input type for the GatherElements operator.", ErrorCode::kUNSUPPORTED_NODE);
 
     const nvinfer1::Dims& idxDims = index->getDimensions();
     const nvinfer1::Dims& daDims = data->getDimensions();

--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -1174,9 +1174,18 @@ DEFINE_BUILTIN_OP_IMPORTER(Dropout)
         std::vector<TensorOrWeights> outputs;
         outputs.push_back(inputs.at(0));
 
-        // Add mask tensor, which is the same shape as the input tensor but contains all 1s of type BOOL
+        // Add mask tensor, which is the same shape as the input tensor
         auto& inputTensor = inputs.at(0).tensor();
-        auto* maskTensor = ctx->network()->addElementWise(inputTensor, inputTensor, nvinfer1::ElementWiseOperation::kEQUAL)->getOutput(0);
+        nvinfer1::ITensor* maskTensor{nullptr};
+        // Post opset 12 the mask tensor contains all 1s. Prior to opset 12 the mask tensor contains all 0s.
+        if (ctx->getOpsetVersion() >= 12)
+        {
+            maskTensor = ctx->network()->addElementWise(inputTensor, inputTensor, nvinfer1::ElementWiseOperation::kEQUAL)->getOutput(0);
+        }
+        else
+        {
+            maskTensor = ctx->network()->addElementWise(inputTensor, inputTensor, nvinfer1::ElementWiseOperation::kLESS)->getOutput(0);
+        }
         outputs.push_back(TensorOrWeights(maskTensor));
         return outputs;
     }
@@ -1361,6 +1370,7 @@ DEFINE_BUILTIN_OP_IMPORTER(GatherElements)
 
     nvinfer1::ITensor* data = &convertToTensor(inputs.at(0), ctx);
     nvinfer1::ITensor* index = &convertToTensor(inputs.at(1), ctx);
+    ASSERT((data.getType() != nvinfer1::DataType::kBOOL) && "This version of TensorRT does not support BOOL input type for the GatherElements operator.", ErrorCode::kUNSUPPORTED_NODE);
 
     const nvinfer1::Dims& idxDims = index->getDimensions();
     const nvinfer1::Dims& daDims = data->getDimensions();
@@ -2046,8 +2056,11 @@ DEFINE_BUILTIN_OP_IMPORTER(If)
         CHECK(onnx2trt::parseGraph(ctx, elseGraph));
         for (auto i = 0; i < nbOutputs; i++)
         {
-            auto* thenTensor = &convertToTensor(ctx->tensors().at(thenGraph.output(i).name()), ctx);
-            auto* elseTensor = &convertToTensor(ctx->tensors().at(elseGraph.output(i).name()), ctx);
+            const auto thenName = thenGraph.output(i).name();
+            const auto elseName = elseGraph.output(i).name();
+            ASSERT(thenName != elseName && "TensorRT requires conditional subgraphs to have different output tensor names!", ErrorCode::kUNSUPPORTED_NODE);
+            auto* thenTensor = &convertToTensor(ctx->tensors().at(thenName), ctx);
+            auto* elseTensor = &convertToTensor(ctx->tensors().at(elseName), ctx);
             auto* condTensor = &convertToTensor(cond, ctx);
             // While the number and datatypes of the outputs of each branch are equal, the shapes may be different
             // TRT only supports dynamic branch selection if the output shapes are equal and if their shapes are broadcastable
@@ -3239,7 +3252,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Resize)
         else
         {
             ASSERT(
-                "TensorRT only supports half_pixel, pytorch_half_pixel, tf_half_pixel_for_nn, asymmetric and "
+                !"TensorRT only supports half_pixel, pytorch_half_pixel, tf_half_pixel_for_nn, asymmetric and "
                 "align_corners transofmration modes!",
                 ErrorCode::kUNSUPPORTED_NODE);
         }

--- a/onnx2trt_utils.cpp
+++ b/onnx2trt_utils.cpp
@@ -396,6 +396,14 @@ int32_t* convertINT64(const int64_t* weightValues, nvinfer1::Dims shape, IImport
 bool convertOnnxPadding(std::vector<int64_t>& onnxPadding, nvinfer1::Dims2& begPadding, nvinfer1::Dims2& endPadding,
     nvinfer1::Permutation& firstPerm, nvinfer1::Permutation& secondPerm)
 {
+    
+    // Input tensor may have been unsqueezed to 4D. Insert no-op pads for all unsqueezed dimensions
+    const size_t minimumSize = 8;
+    while (onnxPadding.size() < minimumSize)
+    {
+        onnxPadding.insert(onnxPadding.begin() + onnxPadding.size() / 2, 0);
+        onnxPadding.insert(onnxPadding.begin(), 0);
+    }
     const auto size = onnxPadding.size();
     const auto half = size / 2;
     std::set<size_t> pads;


### PR DESCRIPTION
- Updates dropout mask tensor for opset < 12
- Adds boolean type assertion for GatherElements
- Adds ASSERTION for If subgraphs to have different output tensor names
- Fixes resize assertion
- Fixes Padding calculation for input tensors < 4D.

Signed-off-by: Kevin Chen <kevinch@nvidia.com>