### PR TITLE
ADD: support of fp16 python inference backend 

### DIFF
--- a/onnx_tensorrt/backend.py
+++ b/onnx_tensorrt/backend.py
@@ -32,7 +32,7 @@ TRT_LOGGER = trt.Logger(trt.Logger.WARNING)
 
 class TensorRTBackendRep(BackendRep):
     def __init__(self, model, device,
-            max_workspace_size=None, serialize_engine=False, verbose=False, **kwargs):
+            max_workspace_size=None, serialize_engine=False, verbose=False, fp16=False, **kwargs):
         if not isinstance(device, Device):
             device = Device(device)
         self._set_device(device)
@@ -44,7 +44,11 @@ class TensorRTBackendRep(BackendRep):
         self.shape_tensor_inputs = []
         self.serialize_engine = serialize_engine
         self.verbose = verbose
+        self.fp16 = fp16
         self.dynamic = False
+
+        if self.fp16:
+            self.config.set_flag(trt.BuilderFlag.FP16)
 
         if self.verbose:
             print(f'\nRunning {model.graph.name}...')


### PR DESCRIPTION
### Enviroment:
CUDA Version: 11.4
TensorRT version: 8.2.0.6-1+cuda11.4 
ONNX version: 1.10.1
Python version: 3.8.10

### Issue:

While working around with converted to onnx model with fp16 precision i have found the following issue:

> Error Code 4: Internal Error (fp16 precision has been set for a layer or layer output, but fp16 is not configured in the builder)

This error occurs when building an engine in python when calling the command: 
`engine = backend.prepare(model, device='CUDA:0', verbose=True)`

Then it was found that in the `backend.py` file there was no initialization of the `fp16` flag in the config for building the engine.

### Solution:
The solution is inspired by the still open pull request [#345](https://github.com/onnx/onnx-tensorrt/pull/345), but it's for the old version of TensorRT. The current solution works on the latest version of TensorRT, which at the time of the pull request is 8.2.0.6.