### PR TITLE
[FixBug] Result Inconsistency By clip(opset < 11) with Integer Inputs

### DIFF
--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -422,9 +422,9 @@ NodeImportResult elementwiseClipHelper(IImporterContext* ctx, ::ONNX_NAMESPACE::
     }
     else
     {
-        alpha = static_cast<ScalarType>(attrs.get("min", alpha));
+        alpha = static_cast<ScalarType>(attrs.get("min", std::numeric_limits<float>::min()));
         alphaT = addConstantScalar(ctx, alpha, onnxType)->getOutput(0);
-        beta = static_cast<ScalarType>(attrs.get("max", beta));
+        beta = static_cast<ScalarType>(attrs.get("max", std::numeric_limits<float>::max()));
         betaT = addConstantScalar(ctx, beta, onnxType)->getOutput(0);
     }
 

--- a/builtin_op_importers.cpp
+++ b/builtin_op_importers.cpp
@@ -11,6 +11,7 @@
 #include "OnnxAttrs.hpp"
 #include "RNNHelpers.hpp"
 #include "ShapeTensor.hpp"
+#include "Status.hpp"
 #include "onnx2trt_utils.hpp"
 
 #include <algorithm> // For std::min, std::max
@@ -381,6 +382,7 @@ template <typename ScalarType>
 NodeImportResult elementwiseClipHelper(IImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node,
     std::vector<TensorOrWeights>& inputs, size_t numInputs, int32_t onnxType)
 {
+    ASSERT( (ctx->getOpsetVersion() > 11 || onnxType == ::ONNX_NAMESPACE::TensorProto::FLOAT || onnxType == ::ONNX_NAMESPACE::TensorProto::DOUBLE || onnxType == ::ONNX_NAMESPACE::TensorProto::FLOAT16 ) && "Clip <= 11 only supports float/float16/double", ErrorCode::kUNSUPPORTED_NODE);
     OnnxAttrs attrs(node, ctx);
     auto* input = &convertToTensor(inputs.at(0), ctx);
     nvinfer1::ITensor* alphaT{nullptr};


### PR DESCRIPTION
## Fix Conversion in Clip (opset < 11)

Consider `clip(0, 1)` in ONNX opeset 10 (Clip-6):

<img width="810" alt="image-20211213190302944" src="https://user-images.githubusercontent.com/38074777/145918479-3f185bb1-9ba2-4584-b89f-6cab76c87844.png">

## Symptom

Result inconsistency! It won't report any error but silently return wrong results. 

<img width="514" alt="image-20211213190449090" src="https://user-images.githubusercontent.com/38074777/145918523-a585a00a-0ce6-4d6b-931e-ce9306546764.png">

## Root Cause

In opset < 11, Clip's attributes ("min" and "max") are `float` types even if its input might be integers/float16, etc. See https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Clip-6

However, during conversion, onnx-trt will simply assume that the attribute types ("min" and "max") are the same type as input tensor, thus resulting in casting a floating-point protobuf binary interpreted as an integer which is undefined behaviour.

Therefore, clip(min=0.0, max=<u>1.0</u>) will regarded as clip(min=0, max=<u>0</u>) during conversion.

To prove it, I put some logs around result parsing 

https://github.com/onnx/onnx-tensorrt/blob/85e79f629fb546a75d61e3027fb259a9529144fe/builtin_op_importers.cpp#L425

<img width="1054" alt="image-20211213191142818" src="https://user-images.githubusercontent.com/38074777/145918652-03947fa4-fb31-4ef2-9b2b-ef1adeb3d263.png">

<img width="492" alt="image-20211213191203395" src="https://user-images.githubusercontent.com/38074777/145918663-6b40279d-7f06-491e-836e-7cc1e914a6b1.png">


As you can see by casting it to float, we get the correct value. The original implementation will cast it to an integer that returns an undefined value and won't alert any error. 

## After the change

<img width="507" alt="image-20211213194816178" src="https://user-images.githubusercontent.com/38074777/145918681-d847c86a-748b-4bb6-a715-401262a7b9c6.png">

## To reproduce the bug

Please use this model generated by PyTorch.

```python
import torch
import onnx
import tensorrt as trt
import onnx
import pycuda.driver as cuda
import numpy as np
import pycuda.autoinit


class Model(torch.nn.Module):
    def __init__(self) -> None:
        super().__init__()

    @torch.no_grad()
    def forward(self, x):
        y = torch.clip(x, 0, 1)
        return y


model = Model()
inputs = (torch.randn(10,).to(torch.int32),)
torch.onnx.export(model, inputs, "output.onnx", verbose=False,
                  input_names=["input"], opset_version=10, output_names=["output"])
```

