### PR TITLE
https://nvbugs/3688087 Fix ctype char* not properly handled bug

### DIFF
--- a/onnx_tensorrt/backend.py
+++ b/onnx_tensorrt/backend.py
@@ -18,6 +18,8 @@ def cudaSetDevice(device_idx):
     ret = libcudart.cudaSetDevice(device_idx)
     if ret != 0:
         error_string = libcudart.cudaGetErrorString(ret)
+        if isinstance(error_string, bytes):
+            error_string = error_string.decode("utf-8")
         raise RuntimeError("cudaSetDevice: " + error_string)
 
 def count_trailing_ones(vals):


### PR DESCRIPTION
Check if the output type of `libcudart.cudaGetErrorString(ret)` is `bytes`.
If so, decode it into `string` type.