### PR TITLE
Remove negative pad check

### DIFF
--- a/onnx2trt_utils.cpp
+++ b/onnx2trt_utils.cpp
@@ -428,10 +428,6 @@ bool convertOnnxPadding(IImporterContext* ctx, int32_t nbInputDims, const std::v
         const auto idx = i - diff;
         const auto pre = onnxPadding[idx];
         const auto post = onnxPadding[onnxPadding.size() / 2U + idx];
-        if (pre < 0 || post < 0)
-        {
-            return false;
-        }
 
         start[i] = -pre;
         totalPadding[i] = pre + post;


### PR DESCRIPTION
ONNX format allows for negative padding, therefore negative pad values should not cause an error.

Fixes issue https://github.com/onnx/onnx-tensorrt/issues/847

Signed-off-by: Jaka Katrašnik <jaka.katrasnik@gmail.com>