### PR TITLE
ONNX-TensorRT 8.6-EA release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 # Version information
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 8)
-set(ONNX2TRT_MINOR 5)
-set(ONNX2TRT_PATCH 1)
+set(ONNX2TRT_MINOR 6)
+set(ONNX2TRT_PATCH 0)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 
 #--------------------------------------------------

--- a/ConditionalHelpers.hpp
+++ b/ConditionalHelpers.hpp
@@ -19,17 +19,16 @@ namespace onnx2trt
 {
 
 // Given a subgraph, find all of its external inputs (tensors entering the subgraph).
-// The result is returned in `subgraphInputs`, which is a map indexed by layer-name and with values indicating a set
-// of external input indices.
-Status getSubgraphInputs(
-    const std::vector<nvinfer1::ILayer*>& newLayers,
-    std::unordered_map<std::string, std::set<int32_t>>& subgraphInputs);
+// The result is returned in `subgraphInputs`, which is a map indexed by ITensor (a tensor entering the subgraph) and
+// with values indicating a set of external input indices.
+Status getSubgraphInputs(std::vector<nvinfer1::ILayer*> const& newLayers,
+    std::unordered_map<nvinfer1::ITensor*, std::set<int32_t>>& subgraphInputs);
 
 // Given a subgraph, find all of its external outputs (tensors exiting the subgraph).
-// The result is returned in `subgraphInputs`, which is a map indexed by layer-name and with values indicating a set
-// of external outputs indices.
+// The result is returned in `subgraphInputs`, which is a map indexed by ITensor (a tensor exiting the subgraph) and
+// with values indicating a set of external outputs indices.
 Status getSubgraphOutputs(const std::vector<nvinfer1::ILayer*>& newLayers,
-    std::unordered_map<std::string, std::set<int32_t>>& subgraphOutputs,
+    std::unordered_map<nvinfer1::ITensor*, std::set<int32_t>>& subgraphOutputs,
     const std::vector<std::string>& reportedOutputs);
 
 // Take a snapshot of the network before and after parsing the subgraph and return a list

--- a/NvOnnxParser.h
+++ b/NvOnnxParser.h
@@ -19,8 +19,10 @@
 #define NV_ONNX_PARSER_MINOR 1
 #define NV_ONNX_PARSER_PATCH 0
 
-static const int NV_ONNX_PARSER_VERSION = ((NV_ONNX_PARSER_MAJOR * 10000) + (NV_ONNX_PARSER_MINOR * 100) + NV_ONNX_PARSER_PATCH);
+static constexpr int32_t NV_ONNX_PARSER_VERSION
+    = ((NV_ONNX_PARSER_MAJOR * 10000) + (NV_ONNX_PARSER_MINOR * 100) + NV_ONNX_PARSER_PATCH);
 
+//!
 //! \typedef SubGraph_t
 //!
 //! \brief The data structure containing the parsing capability of
@@ -28,6 +30,7 @@ static const int NV_ONNX_PARSER_VERSION = ((NV_ONNX_PARSER_MAJOR * 10000) + (NV_
 //!
 typedef std::pair<std::vector<size_t>, bool> SubGraph_t;
 
+//!
 //! \typedef SubGraphCollection_t
 //!
 //! \brief The data structure containing all SubGraph_t partitioned
@@ -44,12 +47,13 @@ namespace nvonnxparser
 {
 
 template <typename T>
-inline int32_t EnumMax();
+constexpr inline int32_t EnumMax();
 
-/** \enum ErrorCode
- *
- * \brief the type of parser error
- */
+//!
+//! \enum ErrorCode
+//!
+//! \brief The type of error that the parser may return
+//!
 enum class ErrorCode : int
 {
     kSUCCESS = 0,
@@ -63,140 +67,256 @@ enum class ErrorCode : int
     kUNSUPPORTED_NODE = 8
 };
 
+//!
+//! Maximum number of flags in the ErrorCode enum.
+//!
+//! \see ErrorCode
+//!
 template <>
-inline int32_t EnumMax<ErrorCode>()
+constexpr inline int32_t EnumMax<ErrorCode>()
 {
     return 9;
 }
 
-/** \class IParserError
- *
- * \brief an object containing information about an error
- */
+//!
+//! \brief Represents one or more OnnxParserFlag values using binary OR
+//! operations, e.g., 1U << OnnxParserFlag::kVERSION_COMPATIBLE
+//!
+//! \see IParser::setFlags() and IParser::getFlags()
+//!
+using OnnxParserFlags = uint32_t;
+
+enum class OnnxParserFlag : int32_t
+{
+    //! Parse the ONNX model into the INetworkDefinition with the intention of building a version-compatible engine in
+    //! TensorRT 8.6. This flag is planned to be deprecated in TensorRT 8.7, and removed in TensorRT 9.0. This will
+    //! choose TensorRT's native InstanceNormalization implementation over the plugin implementation. There may be
+    //! performance degradations when this flag is enabled.
+    kVERSION_COMPATIBLE = 0
+};
+
+//!
+//! Maximum number of flags in the OnnxParserFlag enum.
+//!
+//! \see OnnxParserFlag
+//!
+template <>
+constexpr inline int32_t EnumMax<OnnxParserFlag>()
+{
+    return 1;
+}
+
+//!
+//! \class IParserError
+//!
+//! \brief an object containing information about an error
+//!
 class IParserError
 {
 public:
-    /** \brief the error code
-     */
+    //!
+    //!\brief the error code
+    //!
     virtual ErrorCode code() const = 0;
-    /** \brief description of the error
-     */
+    //!
+    //!\brief description of the error
+    //!
     virtual const char* desc() const = 0;
-    /** \brief source file in which the error occurred
-     */
+    //!
+    //!\brief source file in which the error occurred
+    //!
     virtual const char* file() const = 0;
-    /** \brief source line at which the error occurred
-     */
+    //!
+    //!\brief source line at which the error occurred
+    //!
     virtual int line() const = 0;
-    /** \brief source function in which the error occurred
-     */
+    //!
+    //!\brief source function in which the error occurred
+    //!
     virtual const char* func() const = 0;
-    /** \brief index of the ONNX model node in which the error occurred
-     */
+    //!
+    //!\brief index of the ONNX model node in which the error occurred
+    //!
     virtual int node() const = 0;
 
 protected:
     virtual ~IParserError() {}
 };
 
-/** \class IParser
- *
- * \brief an object for parsing ONNX models into a TensorRT network definition
- */
+//!
+//! \class IParser
+//!
+//! \brief an object for parsing ONNX models into a TensorRT network definition
+//!
 class IParser
 {
 public:
-    /** \brief Parse a serialized ONNX model into the TensorRT network.
-     *         This method has very limited diagnostics. If parsing the serialized model
-     *         fails for any reason (e.g. unsupported IR version, unsupported opset, etc.)
-     *         it the user responsibility to intercept and report the error.
-     *         To obtain a better diagnostic, use the parseFromFile method below.
-     *
-     * \param serialized_onnx_model Pointer to the serialized ONNX model
-     * \param serialized_onnx_model_size Size of the serialized ONNX model
-     *        in bytes
-     * \param model_path Absolute path to the model file for loading external weights if required
-     * \return true if the model was parsed successfully
-     * \see getNbErrors() getError()
-     */
-    virtual bool parse(void const* serialized_onnx_model,
-                       size_t serialized_onnx_model_size,
-                       const char* model_path = nullptr)
+    //!
+    //! \brief Parse a serialized ONNX model into the TensorRT network.
+    //!         This method has very limited diagnostics. If parsing the serialized model
+    //!         fails for any reason (e.g. unsupported IR version, unsupported opset, etc.)
+    //!         it the user responsibility to intercept and report the error.
+    //!         To obtain a better diagnostic, use the parseFromFile method below.
+    //!
+    //! \param serialized_onnx_model Pointer to the serialized ONNX model
+    //! \param serialized_onnx_model_size Size of the serialized ONNX model
+    //!        in bytes
+    //! \param model_path Absolute path to the model file for loading external weights if required
+    //! \return true if the model was parsed successfully
+    //! \see getNbErrors() getError()
+    //!
+    virtual bool parse(
+        void const* serialized_onnx_model, size_t serialized_onnx_model_size, const char* model_path = nullptr)
         = 0;
 
-    /** \brief Parse an onnx model file, which can be a binary protobuf or a text onnx model
-     *         calls parse method inside.
-     *
-     * \param File name
-     * \param Verbosity Level
-     *
-     * \return true if the model was parsed successfully
-     *
-     */
+    //!
+    //! \brief Parse an onnx model file, which can be a binary protobuf or a text onnx model
+    //!         calls parse method inside.
+    //!
+    //! \param onnxModelFile name
+    //! \param verbosity Level
+    //!
+    //! \return true if the model was parsed successfully
+    //!
+    //!
     virtual bool parseFromFile(const char* onnxModelFile, int verbosity) = 0;
 
-    /** \brief Check whether TensorRT supports a particular ONNX model.
-     * 	       If the function returns True, one can proceed to engine building
-     * 	       without having to call \p parse or \p parseFromFile.
-     *
-     * \param serialized_onnx_model Pointer to the serialized ONNX model
-     * \param serialized_onnx_model_size Size of the serialized ONNX model
-     *        in bytes
-     * \param sub_graph_collection Container to hold supported subgraphs
-     * \param model_path Absolute path to the model file for loading external weights if required
-     * \return true if the model is supported
-     */
-    virtual bool supportsModel(void const* serialized_onnx_model,
-                               size_t serialized_onnx_model_size,
-                               SubGraphCollection_t& sub_graph_collection,
-                               const char* model_path = nullptr)
+    //!
+    //!\brief Check whether TensorRT supports a particular ONNX model.
+    //! 	       If the function returns True, one can proceed to engine building
+    //! 	       without having to call \p parse or \p parseFromFile.
+    //!
+    //! \param serialized_onnx_model Pointer to the serialized ONNX model
+    //! \param serialized_onnx_model_size Size of the serialized ONNX model
+    //!        in bytes
+    //! \param sub_graph_collection Container to hold supported subgraphs
+    //! \param model_path Absolute path to the model file for loading external weights if required
+    //! \return true if the model is supported
+    //!
+    virtual bool supportsModel(void const* serialized_onnx_model, size_t serialized_onnx_model_size,
+        SubGraphCollection_t& sub_graph_collection, const char* model_path = nullptr)
         = 0;
 
-    /** \brief Parse a serialized ONNX model into the TensorRT network
-     * with consideration of user provided weights
-     *
-     * \param serialized_onnx_model Pointer to the serialized ONNX model
-     * \param serialized_onnx_model_size Size of the serialized ONNX model
-     *        in bytes
-     * \return true if the model was parsed successfully
-     * \see getNbErrors() getError()
-     */
-    virtual bool parseWithWeightDescriptors(
-        void const* serialized_onnx_model, size_t serialized_onnx_model_size)
-        = 0;
+    //!
+    //!\brief Parse a serialized ONNX model into the TensorRT network
+    //! with consideration of user provided weights
+    //!
+    //! \param serialized_onnx_model Pointer to the serialized ONNX model
+    //! \param serialized_onnx_model_size Size of the serialized ONNX model
+    //!        in bytes
+    //! \return true if the model was parsed successfully
+    //! \see getNbErrors() getError()
+    //!
+    virtual bool parseWithWeightDescriptors(void const* serialized_onnx_model, size_t serialized_onnx_model_size) = 0;
 
-    /** \brief Returns whether the specified operator may be supported by the
-     *         parser.
-     *
-     * Note that a result of true does not guarantee that the operator will be
-     * supported in all cases (i.e., this function may return false-positives).
-     *
-     * \param op_name The name of the ONNX operator to check for support
-     */
+    //!
+    //!\brief Returns whether the specified operator may be supported by the
+    //!         parser.
+    //!
+    //! Note that a result of true does not guarantee that the operator will be
+    //! supported in all cases (i.e., this function may return false-positives).
+    //!
+    //! \param op_name The name of the ONNX operator to check for support
+    //!
     virtual bool supportsOperator(const char* op_name) const = 0;
-    /** \brief destroy this object
-     *
-     * \warning deprecated and planned on being removed in TensorRT 10.0
-     */
+
+    //!
+    //!\brief destroy this object
+    //!
+    //! \warning deprecated and planned on being removed in TensorRT 10.0
+    //!
     TRT_DEPRECATED virtual void destroy() = 0;
-    /** \brief Get the number of errors that occurred during prior calls to
-     *         \p parse
-     *
-     * \see getError() clearErrors() IParserError
-     */
+
+    //!
+    //!\brief Get the number of errors that occurred during prior calls to
+    //!         \p parse
+    //!
+    //! \see getError() clearErrors() IParserError
+    //!
     virtual int getNbErrors() const = 0;
-    /** \brief Get an error that occurred during prior calls to \p parse
-     *
-     * \see getNbErrors() clearErrors() IParserError
-     */
+
+    //!
+    //!\brief Get an error that occurred during prior calls to \p parse
+    //!
+    //! \see getNbErrors() clearErrors() IParserError
+    //!
     virtual IParserError const* getError(int index) const = 0;
-    /** \brief Clear errors from prior calls to \p parse
-     *
-     * \see getNbErrors() getError() IParserError
-     */
+
+    //!
+    //!\brief Clear errors from prior calls to \p parse
+    //!
+    //! \see getNbErrors() getError() IParserError
+    //!
     virtual void clearErrors() = 0;
 
+    //!
+    //! \brief Set the parser flags.
+    //!
+    //! The flags are listed in the OnnxParserFlag enum.
+    //!
+    //! \param OnnxParserFlag The flags used when parsing an ONNX model.
+    //!
+    //! \note This function will override the previous set flags, rather than bitwise ORing the new flag.
+    //!
+    //! \see getFlags()
+    //!
+    virtual void setFlags(OnnxParserFlags onnxParserFlags) noexcept = 0;
+
+    //!
+    //! \brief Get the parser flags. Defaults to 0.
+    //!
+    //! \return The parser flags as a bitmask.
+    //!
+    //! \see setFlags()
+    //!
+    virtual OnnxParserFlags getFlags() const noexcept = 0;
+
+    //!
+    //! \brief clear a parser flag.
+    //!
+    //! clears the parser flag from the enabled flags.
+    //!
+    //! \see setFlags()
+    //!
+    virtual void clearFlag(OnnxParserFlag onnxParserFlag) noexcept = 0;
+
+    //!
+    //! \brief Set a single parser flag.
+    //!
+    //! Add the input parser flag to the already enabled flags.
+    //!
+    //! \see setFlags()
+    //!
+    virtual void setFlag(OnnxParserFlag onnxParserFlag) noexcept = 0;
+
+    //!
+    //! \brief Returns true if the parser flag is set
+    //!
+    //! \see getFlags()
+    //!
+    //! \return True if flag is set, false if unset.
+    //!
+    virtual bool getFlag(OnnxParserFlag onnxParserFlag) const noexcept = 0;
+
     virtual ~IParser() noexcept = default;
+
+    //!
+    //! \brief Query the plugin libraries needed to implement operations used by the parser in a version-compatible
+    //! engine.
+    //!
+    //! This provides a list of plugin libraries on the filesystem needed to implement operations
+    //! in the parsed network.  If you are building a version-compatible engine using this network,
+    //! provide this list to IBuilderConfig::setPluginsToSerialize to serialize these plugins along
+    //! with the version-compatible engine, or, if you want to ship these plugin libraries externally
+    //! to the engine, ensure that IPluginRegistry::loadLibrary is used to load these libraries in the
+    //! appropriate runtime before deserializing the corresponding engine.
+    //!
+    //! \param[out] nbPluginLibs Returns the number of plugin libraries in the array, or -1 if there was an error.
+    //! \return Array of `nbPluginLibs` C-strings describing plugin library paths on the filesystem if nbPluginLibs > 0,
+    //! or nullptr otherwise.  This array is owned by the IParser, and the pointers in the array are only valid until
+    //! the next call to parse(), supportsModel(), parseFromFile(), or parseWithWeightDescriptors().
+    //!
+    virtual char const* const* getUsedVCPluginLibraries(int64_t& nbPluginLibs) const noexcept = 0;
 };
 
 } // namespace nvonnxparser
@@ -210,20 +330,21 @@ namespace nvonnxparser
 namespace
 {
 
-/** \brief Create a new parser object
- *
- * \param network The network definition that the parser will write to
- * \param logger The logger to use
- * \return a new parser object or NULL if an error occurred
- *
- * Any input dimensions that are constant should not be changed after parsing,
- * because correctness of the translation may rely on those constants.
- * Changing a dynamic input dimension, i.e. one that translates to -1 in
- * TensorRT, to a constant is okay if the constant is consistent with the model.
- * Each instance of the parser is designed to only parse one ONNX model once.
- *
- * \see IParser
- */
+//!
+//! \brief Create a new parser object
+//!
+//! \param network The network definition that the parser will write to
+//! \param logger The logger to use
+//! \return a new parser object or NULL if an error occurred
+//!
+//! Any input dimensions that are constant should not be changed after parsing,
+//! because correctness of the translation may rely on those constants.
+//! Changing a dynamic input dimension, i.e. one that translates to -1 in
+//! TensorRT, to a constant is okay if the constant is consistent with the model.
+//! Each instance of the parser is designed to only parse one ONNX model once.
+//!
+//! \see IParser
+//!
 inline IParser* createParser(nvinfer1::INetworkDefinition& network, nvinfer1::ILogger& logger)
 {
     return static_cast<IParser*>(createNvOnnxParser_INTERNAL(&network, &logger, NV_ONNX_PARSER_VERSION));

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For press and other inquiries, please contact Hector Marinez at hmarinez@nvidia.
 
 ## Supported TensorRT Versions
 
-Development on the `main` branch is for the latest version of [TensorRT 8.5.1](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
+Development on the `main` branch is for the latest version of [TensorRT 8.6.0](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
 
 For previous versions of TensorRT, refer to their respective branches.
 
@@ -48,8 +48,8 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 ### Dependencies
 
  - [Protobuf >= 3.0.x](https://github.com/google/protobuf/releases)
- - [TensorRT 8.5.1](https://developer.nvidia.com/tensorrt)
- - [TensorRT 8.5.1 open source libaries (main branch)](https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 8.6.0](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 8.6.0 open source libaries (main branch)](https://github.com/NVIDIA/TensorRT/)
 
 ### Building
 
@@ -92,7 +92,7 @@ Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` 
 
     python3 -m pip install <tensorrt_install_dir>/python/tensorrt-8.x.x.x-cp<python_ver>-none-linux_x86_64.whl
 
-TensorRT 8.5.1 supports ONNX release 1.12.0. Install it with:
+TensorRT 8.6.0 supports ONNX release 1.12.0. Install it with:
 
     python3 -m pip install onnx==1.12.0
 

--- a/TensorOrWeights.hpp
+++ b/TensorOrWeights.hpp
@@ -107,15 +107,15 @@ public:
     {
         if (is_tensor())
         {
-            switch(_tensor->getType())
+            switch (_tensor->getType())
             {
-                case nvinfer1::DataType::kFLOAT:return "FLOAT";
-                case nvinfer1::DataType::kHALF: return "HALF";
-                case nvinfer1::DataType::kINT8: return "INT8";
-                case nvinfer1::DataType::kUINT8: return "UINT8";
-                case nvinfer1::DataType::kINT32: return "INT32";
-                case nvinfer1::DataType::kBOOL: return "BOOL";
-                default: return "UNKNOWN TYPE";
+            case nvinfer1::DataType::kFLOAT:return "FLOAT";
+            case nvinfer1::DataType::kHALF: return "HALF";
+            case nvinfer1::DataType::kINT8: return "INT8";
+            case nvinfer1::DataType::kUINT8: return "UINT8";
+            case nvinfer1::DataType::kINT32: return "INT32";
+            case nvinfer1::DataType::kBOOL: return "BOOL";
+            case nvinfer1::DataType::kFP8: return "FP8";
             }
         }
         else
@@ -130,9 +130,9 @@ public:
             case ::ONNX_NAMESPACE::TensorProto::BOOL: return "BOOL";
             case ::ONNX_NAMESPACE::TensorProto::INT32: return "INT32";
             case ::ONNX_NAMESPACE::TensorProto::INT64: return "INT32";
-            default: return "UNKNOWN TYPE";
             }
         }
+        return "UNKNOWN TYPE";
     }
 };
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,23 @@
 
 # ONNX-TensorRT Changelog
 
+# TensorRT 8.6 EA Release - 2023-3-13
+
+## Added
+
+For more details, see the 8.6 EA release notes for new features added in TensorRT 8.6.
+
+- Added support for `GroupNormalization`, `LayerNormalization`, `IsInf` operations
+- Added support for INT32 input types for `Argmin`, `Argmax`, and `TopK`
+- Added support for `ReverseSequence` operators with dynamic shapes
+- Added support for `TopK` operators with dynamic `K` values
+- Added `OnnxParserFlag` enum and `setFlag` interfaces to the ONNX parser to modify the default parsing behavior
+- Added metadata tracking, now ONNX node metadata will be embedded into TensorRT layers
+
+## Changed
+
+- All cast operations will now use the new `CastLayer` over the pervious `IdentityLayer`. 
+
 # TensorRT 8.5 GA Release - 2022-11-2
 
 ## Added

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -2,7 +2,7 @@
 
 # Supported ONNX Operators
 
-TensorRT 8.5 supports operators up to Opset 17. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md)
+TensorRT 8.6 supports operators up to Opset 17. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md)
 
 TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, INT8, and BOOL
 
@@ -19,8 +19,8 @@ See below for the support matrix of ONNX operators in ONNX-TensorRT.
 | Acosh                     | Y          | FP32, FP16 |
 | Add                       | Y          | FP32, FP16, INT32 |
 | And                       | Y          | BOOL |
-| ArgMax                    | Y          | FP32, FP16 |
-| ArgMin                    | Y          | FP32, FP16 |
+| ArgMax                    | Y          | FP32, FP16, INT32 |
+| ArgMin                    | Y          | FP32, FP16, INT32 |
 | Asin                      | Y          | FP32, FP16 |
 | Asinh                     | Y          | FP32, FP16 |
 | Atan                      | Y          | FP32, FP16 |
@@ -30,7 +30,7 @@ See below for the support matrix of ONNX operators in ONNX-TensorRT.
 | Bernoulli                 | N          |
 | BitShift                  | N          |
 | BlackmanWindow            | N          |
-| Cast                      | Y          | FP32, FP16, INT32, INT8, BOOL |                                                                                                       |
+| Cast                      | Y          | FP32, FP16, INT32, INT8, UINT8, BOOL |                                                                                                       |
 | Ceil                      | Y          | FP32, FP16 |
 | Celu                      | Y          | FP32, FP16 |
 | Clip                      | Y          | FP32, FP16, INT8 |                                                                                        |
@@ -70,7 +70,8 @@ See below for the support matrix of ONNX operators in ONNX-TensorRT.
 | GlobalMaxPool             | Y          | FP32, FP16, INT8 |
 | Greater                   | Y          | FP32, FP16, INT32 |
 | GreaterOrEqual            | Y          | FP32, FP16, INT32 |
-| GridSample                | Y          | FP32, FP16
+| GridSample                | Y          | FP32, FP16 |
+| GroupNormalization        | Y          | FP32, FP16 |
 | GRU                       | Y          | FP32, FP16 | For bidirectional GRUs, activation functions must be the same for both the forward and reverse pass
 | HammingWindow             | N          |
 | HannWindow                | N          |
@@ -80,10 +81,10 @@ See below for the support matrix of ONNX operators in ONNX-TensorRT.
 | Identity                  | Y          | FP32, FP16, INT32, INT8, BOOL |
 | If                        | Y          | FP32, FP16, INT32, BOOL | Output tensors of the two conditional branches must have broadcastable shapes, and must have different names
 | ImageScaler               | Y          | FP32, FP16 |
-| InstanceNormalization     | Y          | FP32, FP16 | Scales `scale` and biases `B` must be initializers. Input rank must be >=3 & <=5                                                                                  |
-| IsInf                     | N          |
+| InstanceNormalization     | Y          | FP32, FP16 |
+| IsInf                     | Y          | FP32, FP16
 | IsNaN                     | Y          | FP32, FP16, INT32 |
-| LayerNormalization        | N          |
+| LayerNormalization        | Y          | FP32, FP16
 | LeakyRelu                 | Y          | FP32, FP16, INT8 |
 | Less                      | Y          | FP32, FP16, INT32 |
 | LessOrEqual               | Y          | FP32, FP16, INT32 |
@@ -143,7 +144,7 @@ See below for the support matrix of ONNX operators in ONNX-TensorRT.
 | Relu                      | Y          | FP32, FP16, INT8 |
 | Reshape                   | Y          | FP32, FP16, INT32, INT8, BOOL |
 | Resize                    | Y          | FP32, FP16 | Supported resize transformation modes: `half_pixel`, `pytorch_half_pixel`, `tf_half_pixel_for_nn`, `asymmetric`, and `align_corners`.<br />Supported resize modes: `nearest`, `linear`.<br />Supported nearest modes: `floor`, `ceil`, `round_prefer_floor`, `round_prefer_ceil`   |
-| ReverseSequence           | Y          | FP32, FP16 | Dynamic input shapes are unsupported
+| ReverseSequence           | Y          | FP32, FP16, INT32, INT8, BOOL |
 | RNN                       | Y          | FP32, FP16 | For bidirectional RNNs, activation functions must be the same for both the forward and reverse pass
 | RoiAlign                  | Y          | FP32, FP16 |
 | Round                     | Y          | FP32, FP16, INT8 |
@@ -186,7 +187,7 @@ See below for the support matrix of ONNX operators in ONNX-TensorRT.
 | TfIdfVectorizer           | N          |
 | ThresholdedRelu           | Y          | FP32, FP16, INT8 |
 | Tile                      | Y          | FP32, FP16, INT32, BOOL |
-| TopK                      | Y          | FP32, FP16 | `K` input must be an initializer
+| TopK                      | Y          | FP32, FP16, INT32 |
 | Transpose                 | Y          | FP32, FP16, INT32, INT8, BOOL |
 | Trilu                     | Y          | FP32, FP16, INT32, INT8, BOOL |
 | Unique                    | N          |

--- a/onnx2trt.hpp
+++ b/onnx2trt.hpp
@@ -47,9 +47,15 @@ public:
     virtual StringMap<std::string>& loopTensors() = 0;
     virtual void setOnnxFileLocation(std::string location) = 0;
     virtual std::string getOnnxFileLocation() = 0;
-    virtual void registerTensor(TensorOrWeights tensor, const std::string& basename, bool const checkUniqueName = false)
-        = 0;
-    virtual void registerLayer(nvinfer1::ILayer* layer, const std::string& basename) = 0;
+    virtual void registerTensor(TensorOrWeights tensor, std::string const& basename, bool const checkUniqueName = false) = 0;
+
+    //! Register a layer, which ensures it has a unique name.
+    //! If node!=nullptr, set the metadata for the layer to the node's name.
+    virtual void registerLayer(nvinfer1::ILayer* layer, std::string const& basename, ::ONNX_NAMESPACE::NodeProto const* node) = 0;
+
+    //! Short form of register layer to use when the basename is the node's name.
+    virtual void registerLayer(nvinfer1::ILayer* layer, ::ONNX_NAMESPACE::NodeProto const& node) = 0;
+
     virtual ShapedWeights createTempWeights(ShapedWeights::DataType type, nvinfer1::Dims shape, uint8_t value = 0) = 0;
     virtual int64_t getOpsetVersion(const char* domain = "") const = 0;
     virtual nvinfer1::ILogger& logger() = 0;
@@ -57,11 +63,25 @@ public:
     virtual nvinfer1::IErrorRecorder* getErrorRecorder() const = 0;
     virtual nvinfer1::IConstantLayer* getConstantLayer(const char* name) const = 0;
 
+    virtual void setFlags(nvonnxparser::OnnxParserFlags const& onnxParserFlags) = 0;
+    virtual nvonnxparser::OnnxParserFlags getFlags() const = 0;
+
     //! Push a new scope for base names (ONNX names).
     virtual void pushBaseNameScope() = 0;
 
     //! Revert actions of registerTensor for names in the top scope and pop it.
     virtual void popBaseNameScope() = 0;
+
+    //! Declare the given node requires a plugin library for the given pluginName, which is provided by the
+    //! logical library name pluginLib (should correspond to the DLL/DSO name with suffix and "lib" prefix stripped,
+    //! e.g. nvinfer_vc_plugin for libnvinfer_vc_plugin.so.8).
+    virtual void addUsedVCPluginLibrary(
+        ::ONNX_NAMESPACE::NodeProto const& node, char const* pluginName, char const* pluginLib)
+        = 0;
+
+    // Returns a list of strings corresponding to paths to the used VC plugins on disk.  May throw on error.
+    virtual std::vector<std::string> getUsedVCPluginLibraries() = 0;
+
 protected:
     virtual ~IImporterContext() {}
 };

--- a/trt_utils.hpp
+++ b/trt_utils.hpp
@@ -22,7 +22,8 @@ inline int getDtypeSize(nvinfer1::DataType trtDtype)
     {
     case nvinfer1::DataType::kFLOAT: return 4;
     case nvinfer1::DataType::kUINT8:
-    case nvinfer1::DataType::kINT8: return 1;
+    case nvinfer1::DataType::kINT8:
+    case nvinfer1::DataType::kFP8: return 1;
     case nvinfer1::DataType::kHALF: return 2;
     case nvinfer1::DataType::kINT32:
         return 4;
@@ -156,9 +157,9 @@ inline ::ONNX_NAMESPACE::TensorProto_DataType trtDataTypeToONNX(nvinfer1::DataTy
     case nvinfer1::DataType::kINT8: return ::ONNX_NAMESPACE::TensorProto::INT8;
     case nvinfer1::DataType::kBOOL: return ::ONNX_NAMESPACE::TensorProto::BOOL;
     case nvinfer1::DataType::kUINT8: return ::ONNX_NAMESPACE::TensorProto::UINT8;
-    default: return ::ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED;
+    case nvinfer1::DataType::kFP8: break;
     }
-    throw std::runtime_error{"Unreachable"};
+    return ::ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED;
 }
 
 } // namespace onnx2trt


### PR DESCRIPTION
# TensorRT 8.6 EA Release - 2023-3-13

## Added

For more details, see the 8.6 EA release notes for new features added in TensorRT 8.6.

- Added support for `GroupNormalization`, `LayerNormalization`, `IsInf` operations
- Added support for INT32 input types for `Argmin`, `Argmax`, and `TopK`
- Added support for `ReverseSequence` operators with dynamic shapes
- Added support for `TopK` operators with dynamic `K` values
- Added `OnnxParserFlag` enum and `setFlag` interfaces to the ONNX parser to modify the default parsing behavior
- Added metadata tracking, now ONNX node metadata will be embedded into TensorRT layers

## Changed

- All cast operations will now use the new `CastLayer` over the pervious `IdentityLayer`. 