### PR TITLE
ONNX-TensorRT 9.0 GA Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 9)
 set(ONNX2TRT_MINOR 0)
-set(ONNX2TRT_PATCH 0)
+set(ONNX2TRT_PATCH 1)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 
 #--------------------------------------------------
@@ -116,11 +116,18 @@ set_target_properties(nvonnxparser PROPERTIES
   SOVERSION ${ONNX2TRT_MAJOR}
   LINK_DEPENDS ${PARSER_LINKER_SCRIPT}
   LINK_FLAGS "-Wl,--version-script=${PARSER_LINKER_SCRIPT}"
+  ARCHIVE_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+  LIBRARY_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+  RUNTIME_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
 )
 add_library(nvonnxparser_static STATIC ${IMPORTER_SOURCES})
 target_include_directories(nvonnxparser_static PUBLIC ${ONNX_INCLUDE_DIRS} ${TENSORRT_INCLUDE_DIR} ${CUDA_INCLUDE_DIR})
 target_link_libraries(nvonnxparser_static PUBLIC onnx_proto ${PROTOBUF_LIBRARY} ${TENSORRT_LIBRARY})
-
+set_target_properties(nvonnxparser_static PROPERTIES
+  ARCHIVE_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+  LIBRARY_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+  RUNTIME_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
+)
 # --------------------------------
 # Onnxifi library
 # --------------------------------

--- a/ConditionalHelpers.cpp
+++ b/ConditionalHelpers.cpp
@@ -75,7 +75,7 @@ Status addConditionalInputLayer(IImporterContext* ctx, nvinfer1::IIfConditional*
 // Take a snapshot of the network before and after parsing the subgraph and return a list
 // of newly added network layers.
 Status importSubgraph(IImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const& subgraph,
-    std::vector<nvinfer1::ILayer*>& newLayers, StringMap<TensorOrWeights>& subgraphTensors)
+    std::vector<nvinfer1::ILayer*>& newLayers, std::vector<TensorOrWeights>& subgraphTensors)
 {
     auto net = ctx->network();
     int32_t beforeSubgraph = net->getNbLayers();
@@ -88,7 +88,7 @@ Status importSubgraph(IImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const&
     for (int32_t i = 0; i < subgraph.output_size(); ++i)
     {
         std::string name = subgraph.output(i).name();
-        subgraphTensors.emplace(std::make_pair(name, ctx->tensors().at(name)));
+        subgraphTensors.push_back(ctx->tensors().at(name));
     }
 
     for (int32_t i = beforeSubgraph; i < net->getNbLayers(); i++)
@@ -142,81 +142,6 @@ Status addIfInputLayers(IImporterContext* ctx, nvinfer1::IIfConditional* conditi
         addConditionalInputIfNeeded(ctx, conditional, inputsMap, *layer, subgraphInputsMap);
     }
 
-    return Status::success();
-}
-
-// Add an IConditionalOutputLayer to `layer`'s outputs.
-Status addIfOutputLayers(IImporterContext* ctx, nvinfer1::IIfConditional* conditional,
-    ::ONNX_NAMESPACE::GraphProto const& thenGraph, std::vector<nvinfer1::ILayer*> const& thenLayers,
-    StringMap<TensorOrWeights> const& thenSubgraphTensors, ::ONNX_NAMESPACE::GraphProto const& elseGraph,
-    std::vector<nvinfer1::ILayer*> const& elseLayers, StringMap<TensorOrWeights> const& elseSubgraphTensors,
-    std::vector<TensorOrWeights>& graphOutputs)
-{
-    // Reported outputs are outputs that the ONNX model reports as subgraph outputs.  This list is
-    // not sufficient because it may produce names that are not fully compatible with TensorRT's naming.
-    // We use this list to help find the subgraph (SG) output tensors.
-    auto getReportedOutputs
-        = [&ctx](const ::ONNX_NAMESPACE::GraphProto& body, std::vector<std::string>& reportedOutputs) {
-              // Assuming that the subgraph was imported already, we can iterate on its output tensors.
-              const auto nbOutputs = body.output_size();
-              for (auto i = 0; i < nbOutputs; i++)
-              {
-                  reportedOutputs.emplace_back(body.output(i).name());
-              }
-          };
-
-    std::unordered_map<nvinfer1::ITensor*, std::set<int32_t>> thenOutputs;
-    std::unordered_map<nvinfer1::ITensor*, std::set<int32_t>> elseOutputs;
-
-    std::vector<std::string> thenReportedOutputs;
-    getReportedOutputs(thenGraph, thenReportedOutputs);
-    getSubgraphOutputs(thenLayers, thenOutputs, thenReportedOutputs);
-    std::vector<std::string> elseReportedOutputs;
-    getReportedOutputs(elseGraph, elseReportedOutputs);
-    getSubgraphOutputs(elseLayers, elseOutputs, elseReportedOutputs);
-
-    // Retrieve the output tensors of a subgraph (tensors exiting the subgraph).
-    auto getSubgraphOutputTensors
-        = [](IImporterContext* ctx, std::vector<nvinfer1::ITensor*>& sgOutputs, SubgraphPortsMap& subgraphOutputs,
-              ::ONNX_NAMESPACE::GraphProto const& subgraph, std::vector<nvinfer1::ILayer*> subgraphLayers,
-              StringMap<TensorOrWeights> const& subgraphTensors) {
-              for (auto const& pair : subgraphOutputs)
-              {
-                  sgOutputs.push_back(pair.first);
-              }
-
-              if (sgOutputs.empty())
-              {
-                  // No new layers, so we can't deduce the outputs and have to use what ONNX tells us.
-                  const int32_t nbOutputs = subgraph.output_size();
-                  for (int32_t outIdx = 0; outIdx < nbOutputs; outIdx++)
-                  {
-                      const auto thenName = subgraph.output(outIdx).name();
-                      TensorOrWeights tw = subgraphTensors.at(thenName);
-                      auto* thenTensor = &convertToTensor(tw, ctx);
-                      sgOutputs.push_back(thenTensor);
-                  }
-              }
-          };
-
-    std::vector<nvinfer1::ITensor*> thenOutputTensors;
-    getSubgraphOutputTensors(ctx, thenOutputTensors, thenOutputs, thenGraph, thenLayers, thenSubgraphTensors);
-
-    std::vector<nvinfer1::ITensor*> elseSGOutputTensors;
-    getSubgraphOutputTensors(ctx, elseSGOutputTensors, elseOutputs, elseGraph, elseLayers, elseSubgraphTensors);
-
-    ASSERT(thenOutputTensors.size() == elseSGOutputTensors.size()
-            && "The then/else branches of an If operator must have the same number of outputs.",
-        ErrorCode::kINVALID_NODE);
-
-    // Add an ConditionalOutputLayer with one output and two inputs
-    // (one from the thenGraph and another from the elseGraph).
-    for (size_t i = 0; i < elseSGOutputTensors.size(); i++)
-    {
-        auto* outputLayer = conditional->addOutput(*thenOutputTensors[i], *elseSGOutputTensors[i]);
-        ctx->registerLayer(outputLayer, std::string(conditional->getName()) + "_OutputLayer", nullptr);
-        graphOutputs.emplace_back(outputLayer->getOutput(0));
-    }
     return Status::success();
 }
 

--- a/ConditionalHelpers.hpp
+++ b/ConditionalHelpers.hpp
@@ -34,19 +34,12 @@ Status getSubgraphOutputs(const std::vector<nvinfer1::ILayer*>& newLayers,
 // Take a snapshot of the network before and after parsing the subgraph and return a list
 // of newly added network layers.
 Status importSubgraph(IImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const& subgraph,
-    std::vector<nvinfer1::ILayer*>& newLayers, StringMap<TensorOrWeights>& subgraphTensors);
+    std::vector<nvinfer1::ILayer*>& newLayers, std::vector<TensorOrWeights>& subgraphTensors);
 
 using InputsMap = std::unordered_map<std::string, nvinfer1::IIfConditionalInputLayer*>;
 
 // Add IIfConditionalInputLayers to the inputs of the subgraph indicated by `subgraph`.
 onnx2trt::Status addIfInputLayers(IImporterContext* ctx, nvinfer1::IIfConditional* conditional, InputsMap& inputsMap,
     const std::vector<nvinfer1::ILayer*>& newLayers);
-
-// Add IIfConditionalOutputLayers to the outputs of the subgraph indicated by `subgraph`.
-onnx2trt::Status addIfOutputLayers(IImporterContext* ctx, nvinfer1::IIfConditional* conditional,
-    ::ONNX_NAMESPACE::GraphProto const& thenGraph, std::vector<nvinfer1::ILayer*> const& thenLayers,
-    StringMap<TensorOrWeights> const& thenSubgraphTensors, ::ONNX_NAMESPACE::GraphProto const& elseGraph,
-    std::vector<nvinfer1::ILayer*> const& elseLayers, StringMap<TensorOrWeights> const& elseSubgraphTensors,
-    std::vector<TensorOrWeights>& graphOutputs);
 
 } // namespace onnx2trt

--- a/ImporterContext.hpp
+++ b/ImporterContext.hpp
@@ -117,8 +117,8 @@ class ImporterContext final : public IImporterContext
     //! Map holding FunctionProtos
     StringMap<::ONNX_NAMESPACE::FunctionProto> mLocalFunctions;
 
-    //! Vector to hold current local function names
-    std::vector<std::string> mLocalFunctionStack;
+    //! Vector to hold current local function names and attributes
+    std::vector<std::pair<std::string, StringMap<::ONNX_NAMESPACE::AttributeProto const*>>> mLocalFunctionStack;
 
     //! Vector to hold expected graph outputs
     std::vector<::ONNX_NAMESPACE::ValueInfoProto> mGraphOutputNames;
@@ -336,7 +336,7 @@ public:
     {
         return mLocalFunctions;
     }
-    std::vector<std::string>& localFunctionStack() override
+    std::vector<std::pair<std::string, StringMap<::ONNX_NAMESPACE::AttributeProto const*>>>& localFunctionStack() override
     {
         return mLocalFunctionStack;
     }

--- a/OnnxAttrs.hpp
+++ b/OnnxAttrs.hpp
@@ -29,7 +29,7 @@ public:
         }
     }
 
-    bool count(const std::string& key) const
+    bool count(std::string const& key) const
     {
         return _attrs.count(key);
     }
@@ -43,17 +43,16 @@ public:
         return _attrs.at(key);
     }
 
-    ::ONNX_NAMESPACE::AttributeProto::AttributeType type(const std::string& key) const
+    ::ONNX_NAMESPACE::AttributeProto::AttributeType type(std::string const& key) const
     {
         return this->at(key)->type();
     }
 
+    template <typename T>
+    T get(std::string const& key) const;
 
     template <typename T>
-    T get(const std::string& key) const;
-
-    template <typename T>
-    T get(const std::string& key, T const& default_value) const
+    T get(std::string const& key, T const& default_value) const
     {
         return _attrs.count(key) ? this->get<T>(key) : default_value;
     }

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,13 @@
 
 # ONNX-TensorRT Changelog
 
+# TensorRT 9.0 GA Release - 2023-9-5
+For more details, see the 9.0 GA release notes for the fixes since 9.0 EA.
+
+- Added support for FP8 and BF16 datatypes.
+- Fixed a bug that previously caused `If` nodes to fail import due to branch output size mismatch
+- Improved support for importing ONNX Local Functions
+
 # TensorRT 9.0 EA Release - 2023-8-4
 For more details, see the 9.0 EA release notes for the fixes since 8.6 GA.
 

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -4,9 +4,11 @@
 
 TensorRT 9.0 supports operators up to Opset 19. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md)
 
-TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, INT8, and BOOL
+TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, INT32, INT64, FP8, INT8, UINT8, and BOOL
 
 > Note: There is limited support for DOUBLE type. TensorRT will attempt to cast DOUBLE down to FLOAT, clamping values to `+-FLT_MAX` if necessary.
+> Note: INT8 and FP8 support is available only through quantization from a type with higher precision.
+> Note: UINT8 is only supported as network input or output tensor types.
 
 See below for the support matrix of ONNX operators in ONNX-TensorRT.
 
@@ -14,147 +16,148 @@ See below for the support matrix of ONNX operators in ONNX-TensorRT.
 
 | Operator                  | Supported  | Supported Types | Restrictions                                                                                                           |
 |---------------------------|------------|-----------------|------------------------------------------------------------------------------------------------------------------------|
-| Abs                       | Y          | FP32, FP16, INT32, INT64 |
-| Acos                      | Y          | FP32, FP16 |
-| Acosh                     | Y          | FP32, FP16 |
-| Add                       | Y          | FP32, FP16, INT32, INT64 |
+| Abs                       | Y          | FP32, FP16, BF16, INT32, INT64, FP8, INT8 |
+| Acos                      | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Acosh                     | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Add                       | Y          | FP32, FP16, BF16, INT32, INT64, FP8, INT8 |
 | And                       | Y          | BOOL |
-| ArgMax                    | Y          | FP32, FP16, INT32, INT64 |
-| ArgMin                    | Y          | FP32, FP16, INT32, INT64 |
-| Asin                      | Y          | FP32, FP16 |
-| Asinh                     | Y          | FP32, FP16 |
-| Atan                      | Y          | FP32, FP16 |
-| Atanh                     | Y          | FP32, FP16 |
-| AveragePool               | Y          | FP32, FP16, INT8, INT32 | 2D or 3D Pooling only                                                                                                                    |
-| BatchNormalization        | Y          | FP32, FP16 |
+| ArgMax                    | Y          | FP32, FP16, BF16, INT32, INT64 |
+| ArgMin                    | Y          | FP32, FP16, BF16, INT32, INT64 |
+| Asin                      | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Asinh                     | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Atan                      | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Atanh                     | Y          | FP32, FP16, BF16, FP8, INT8 |
+| AveragePool               | Y          | FP32, FP16, BF16, FP8, INT8 | 2D or 3D Pooling only                                                                                                                    |
+| BatchNormalization        | Y          | FP32, FP16, BF16 |
 | Bernoulli                 | N          |
 | BitShift                  | N          |
 | BlackmanWindow            | N          |
-| Cast                      | Y          | FP32, FP16, INT32, INT64, INT8, UINT8, BOOL |                                                                                                       |
-| Ceil                      | Y          | FP32, FP16 |
-| Celu                      | Y          | FP32, FP16 |
-| Clip                      | Y          | FP32, FP16, INT8 |                                                                                        |
+| Cast                      | Y          | FP32, FP16, BF16, INT32, INT64, FP8, INT8, UINT8, BOOL |                                                                                                       |
+| CastLike                  | N          |
+| Ceil                      | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Celu                      | Y          | FP32, FP16 BF16|
+| Clip                      | Y          | FP32, FP16, BF16,INT8 |                                                                                        |
 | Compress                  | N          |
-| Concat                    | Y          | FP32, FP16, INT32, INT64, INT8, BOOL |
+| Concat                    | Y          | FP32, FP16, BF16, INT32, INT64, FP8, INT8, BOOL |
 | ConcatFromSequence        | N          |
-| Constant                  | Y          | FP32, FP16, INT32, INT64, INT8, BOOL |
+| Constant                  | Y          | FP32, FP16, BF16, INT32, INT64, INT8, BOOL |
 | ConstantOfShape           | Y          | FP32 |
-| Conv                      | Y          | FP32, FP16, INT8 |
+| Conv                      | Y          | FP32, FP16, BF16, FP8, INT8 |
 | ConvInteger               | N          |
-| ConvTranspose             | Y          | FP32, FP16, INT8 |
-| Cos                       | Y          | FP32, FP16 |
-| Cosh                      | Y          | FP32, FP16 |
-| CumSum                    | Y          | FP32, FP16 | `axis` must be an initializer                                                                                                            |
+| ConvTranspose             | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Cos                       | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Cosh                      | Y          | FP32, FP16, BF16, FP8, INT8 |
+| CumSum                    | Y          | FP32, FP16, BF16 | `axis` must be an initializer                                                                                                            |
 | DFT                       | N          |
-| DepthToSpace              | Y          | FP32, FP16, INT32, INT64 |
-| DequantizeLinear          | Y          | INT8 | `x_zero_point` must be zero                                                                                    |
+| DepthToSpace              | Y          | FP32, FP16, BF16, INT32, INT64 |
+| DequantizeLinear          | Y          | INT8, FP8 | `x_zero_point` must be zero                                                                                    |
 | Det                       | N          |
-| Div                       | Y          | FP32, FP16, INT32, INT64 |
-| Dropout                   | Y          | FP32, FP16 |
+| Div                       | Y          | FP32, FP16, BF16, INT32, INT64, FP8, INT8 |
+| Dropout                   | Y          | FP32, FP16, BF16 |
 | DynamicQuantizeLinear     | N          |
-| Einsum                    | Y          | FP32, FP16 | Ellipsis and diagonal operations are not supported. Broadcasting between inputs is not supported
-| Elu                       | Y          | FP32, FP16, INT8 |
-| Equal                     | Y          | FP32, FP16, INT32, INT64 |
-| Erf                       | Y          | FP32, FP16 |
-| Exp                       | Y          | FP32, FP16 |
-| Expand                    | Y          | FP32, FP16, INT32, INT64, BOOL |
-| EyeLike                   | Y          | FP32, FP16, INT32, INT64, BOOL |
-| Flatten                   | Y          | FP32, FP16, INT32, INT64, BOOL |
-| Floor                     | Y          | FP32, FP16 |
-| Gather                    | Y          | FP32, FP16, INT8, INT32, INT64, BOOL |
-| GatherElements            | Y          | FP32, FP16, INT8, INT32, INT64, BOOL |
-| GatherND                  | Y          | FP32, FP16, INT8, INT32, INT64, BOOL |
-| Gemm                      | Y          | FP32, FP16, INT8 |
-| GlobalAveragePool         | Y          | FP32, FP16, INT8 |
-| GlobalLpPool              | Y          | FP32, FP16, INT8 |
-| GlobalMaxPool             | Y          | FP32, FP16, INT8 |
-| Greater                   | Y          | FP32, FP16, INT32, INT64 |
-| GreaterOrEqual            | Y          | FP32, FP16, INT32, INT64 |
+| Einsum                    | Y          | FP32, FP16, BF16 |
+| Elu                       | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Equal                     | Y          | FP32, FP16, BF16, INT32, INT64 |
+| Erf                       | Y          | FP32, FP16, BF16 |
+| Exp                       | Y          | FP32, FP16, BF16 |
+| Expand                    | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
+| EyeLike                   | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
+| Flatten                   | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
+| Floor                     | Y          | FP32, FP16, BF16|
+| Gather                    | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64, BOOL |
+| GatherElements            | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64, BOOL |
+| GatherND                  | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64, BOOL |
+| Gemm                      | Y          | FP32, FP16, BF16, FP8, INT8 |
+| GlobalAveragePool         | Y          | FP32, FP16, BF16, FP8, INT8 |
+| GlobalLpPool              | Y          | FP32, FP16, BF16, FP8, INT8 |
+| GlobalMaxPool             | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Greater                   | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| GreaterOrEqual            | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
 | GridSample                | Y          | FP32, FP16 |
-| GroupNormalization        | Y          | FP32, FP16 |
-| GRU                       | Y          | FP32, FP16 | For bidirectional GRUs, activation functions must be the same for both the forward and reverse pass
+| GroupNormalization        | Y          | FP32, FP16, BF16 |
+| GRU                       | Y          | FP32, FP16, BF16 | For bidirectional GRUs, activation functions must be the same for both the forward and reverse pass
 | HammingWindow             | N          |
 | HannWindow                | N          |
-| HardSwish                 | Y          | FP32, FP16, INT8 |
-| HardSigmoid               | Y          | FP32, FP16, INT8 |
+| HardSwish                 | Y          | FP32, FP16, BF16, FP8, INT8 |
+| HardSigmoid               | Y          | FP32, FP16, BF16, FP8, INT8 |
 | Hardmax                   | N          |
-| Identity                  | Y          | FP32, FP16, INT32, INT64, INT8, BOOL |
-| If                        | Y          | FP32, FP16, INT32, INT64, BOOL | Output tensors of the two conditional branches must have broadcastable shapes, and must have different names
-| ImageScaler               | Y          | FP32, FP16 |
-| InstanceNormalization     | Y          | FP32, FP16 |
-| IsInf                     | Y          | FP32, FP16
-| IsNaN                     | Y          | FP32, FP16, INT32, INT64 |
-| LayerNormalization        | Y          | FP32, FP16
-| LeakyRelu                 | Y          | FP32, FP16, INT8 |
-| Less                      | Y          | FP32, FP16, INT32, INT64 |
-| LessOrEqual               | Y          | FP32, FP16, INT32, INT64 |
-| Log                       | Y          | FP32, FP16 |
-| LogSoftmax                | Y          | FP32, FP16 |
-| Loop                      | Y          | FP32, FP16, INT32, INT64, BOOL |
-| LRN                       | Y          | FP32, FP16 |
-| LSTM                      | Y          | FP32, FP16 | For bidirectional LSTMs, activation functions must be the same for both the forward and reverse pass
-| LpNormalization           | Y          | FP32, FP16 |
-| LpPool                    | Y          | FP32, FP16, INT8 |
-| MatMul                    | Y          | FP32, FP16 |
+| Identity                  | Y          | FP32, FP16, BF16, INT32, INT64, FP8, INT8, BOOL |
+| If                        | Y          | FP32, FP16, BF16, INT32, INT64, BOOL | Output tensors of the two conditional branches must have broadcastable shapes, and must have different names
+| ImageScaler               | Y          | FP32, FP16, BF16|
+| InstanceNormalization     | Y          | FP32, FP16, BF16 |
+| IsInf                     | Y          | FP32, FP16, BF16, FP8, INT8 |
+| IsNaN                     | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| LayerNormalization        | Y          | FP32, FP16, BF16
+| LeakyRelu                 | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Less                      | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| LessOrEqual               | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| Log                       | Y          | FP32, FP16, BF16, FP8, INT8 |
+| LogSoftmax                | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Loop                      | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
+| LRN                       | Y          | FP32, FP16, BF16 |
+| LSTM                      | Y          | FP32, FP16, BF16 | For bidirectional LSTMs, activation functions must be the same for both the forward and reverse pass
+| LpNormalization           | Y          | FP32, FP16, BF16 |
+| LpPool                    | Y          | FP32, FP16, BF16, FP8, INT8 |
+| MatMul                    | Y          | FP32, FP16, BF16, FP8, INT8 |
 | MatMulInteger             | N          |
-| Max                       | Y          | FP32, FP16, INT32, INT64 |
-| MaxPool                   | Y          | FP32, FP16, INT8 | 2D or 3D pooling only. `Indices` output tensor unsupported
+| Max                       | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| MaxPool                   | Y          | FP32, FP16, BF16, FP8, INT8 | 2D or 3D pooling only. `Indices` output tensor unsupported
 | MaxRoiPool                | N          |
 | MaxUnpool                 | N          |
-| Mean                      | Y          | FP32, FP16, INT32, INT64 |
-| MeanVarianceNormalization | Y          | FP32, FP16 |
+| Mean                      | Y          | FP32, FP16, BF16, FP8, INT32, INT64 |
+| MeanVarianceNormalization | Y          | FP32, FP16, BF16|
 | MelWeightMatrix           | N          |
-| Min                       | Y          | FP32, FP16, INT32, INT64 |
-| Mod                       | Y          | FP32, FP16, INT32, INT64 |
-| Mul                       | Y          | FP32, FP16, INT32, INT64 |
+| Min                       | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| Mod                       | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| Mul                       | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
 | Multinomial               | N          |
-| Neg                       | Y          | FP32, FP16, INT32, INT64 |
+| Neg                       | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
 | NegativeLogLikelihoodLoss | N          |
 | NonMaxSuppression         | Y          | FP32, FP16 |
 | NonZero                   | Y          | FP32, FP16
 | Not                       | Y          | BOOL |
-| OneHot                    | Y          | FP32, FP16, INT32, INT64, BOOL |
+| OneHot                    | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
 | Optional                  | N          |
 | OptionalGetElement        | N          |
 | OptionalHasElement        | N          |
 | Or                        | Y          | BOOL |
-| Pad                       | Y          | FP32, FP16, INT8, INT32, INT64 |
-| ParametricSoftplus        | Y          | FP32, FP16, INT8 |
-| Pow                       | Y          | FP32, FP16 |
-| PRelu                     | Y          | FP32, FP16, INT8 |
+| Pad                       | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| ParametricSoftplus        | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Pow                       | Y          | FP32, FP16, BF16, FP8, INT8 |
+| PRelu                     | Y          | FP32, FP16, BF16, FP8, INT8 |
 | QLinearConv               | N          |
 | QLinearMatMul             | N          |
-| QuantizeLinear            | Y          | FP32, FP16 | `y_zero_point` must be 0                                                                   |
-| RandomNormal              | Y          | FP32, FP16 | `seed` value is ignored by TensorRT
-| RandomNormalLike          | Y          | FP32, FP16 | `seed` value is ignored by TensorRT
-| RandomUniform             | Y          | FP32, FP16 | `seed` value is ignored by TensorRT
-| RandomUniformLike         | Y          | FP32, FP16 | `seed` value is ignored by TensorRT
-| Range                     | Y          | FP32, FP16, INT32, INT64 |
-| Reciprocal                | Y          | FP32, FP16 |
-| ReduceL1                  | Y          | FP32, FP16 |
-| ReduceL2                  | Y          | FP32, FP16 |
-| ReduceLogSum              | Y          | FP32, FP16 |
-| ReduceLogSumExp           | Y          | FP32, FP16 |
-| ReduceMax                 | Y          | FP32, FP16 |
-| ReduceMean                | Y          | FP32, FP16 |
-| ReduceMin                 | Y          | FP32, FP16 |
-| ReduceProd                | Y          | FP32, FP16 |
-| ReduceSum                 | Y          | FP32, FP16 |
-| ReduceSumSquare           | Y          | FP32, FP16 |
-| Relu                      | Y          | FP32, FP16, INT8 |
-| Reshape                   | Y          | FP32, FP16, INT32, INT64, INT8, BOOL |
-| Resize                    | Y          | FP32, FP16 | Supported resize transformation modes: `half_pixel`, `pytorch_half_pixel`, `tf_half_pixel_for_nn`, `asymmetric`, and `align_corners`.<br />Supported resize modes: `nearest`, `linear`.<br />Supported nearest modes: `floor`, `ceil`, `round_prefer_floor`, `round_prefer_ceil`   |
-| ReverseSequence           | Y          | FP32, FP16, INT32, INT64, INT8, BOOL |
-| RNN                       | Y          | FP32, FP16 | For bidirectional RNNs, activation functions must be the same for both the forward and reverse pass
+| QuantizeLinear            | Y          | FP32, FP16, BF16 | `y_zero_point` must be 0                                                                   |
+| RandomNormal              | Y          | FP32, FP16, BF16, INT8 | `seed` value is ignored by TensorRT
+| RandomNormalLike          | Y          | FP32, FP16, BF16, INT8 | `seed` value is ignored by TensorRT
+| RandomUniform             | Y          | FP32, FP16, BF16, INT8 | `seed` value is ignored by TensorRT
+| RandomUniformLike         | Y          | FP32, FP16, BF16, INT8 | `seed` value is ignored by TensorRT
+| Range                     | Y          | FP32, FP16, BF16, INT32, INT64 |
+| Reciprocal                | Y          | FP32, FP16, BF16, FP8, INT8 |
+| ReduceL1                  | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| ReduceL2                  | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| ReduceLogSum              | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| ReduceLogSumExp           | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| ReduceMax                 | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| ReduceMean                | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| ReduceMin                 | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| ReduceProd                | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| ReduceSum                 | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| ReduceSumSquare           | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| Relu                      | Y          | FP32, FP16, BF16, INT8, INT32, INT64 |
+| Reshape                   | Y          | FP32, FP16, BF16, INT32, INT64, FP8, INT8, BOOL |
+| Resize                    | Y          | FP32, FP16, BF16 | Supported resize transformation modes: `half_pixel`, `pytorch_half_pixel`, `tf_half_pixel_for_nn`, `asymmetric`, and `align_corners`.<br />Supported resize modes: `nearest`, `linear`.<br />Supported nearest modes: `floor`, `ceil`, `round_prefer_floor`, `round_prefer_ceil`   |
+| ReverseSequence           | Y          | FP32, FP16, BF16, INT32, INT64, FP8, INT8, BOOL |
+| RNN                       | Y          | FP32, FP16, BF16| For bidirectional RNNs, activation functions must be the same for both the forward and reverse pass
 | RoiAlign                  | Y          | FP32, FP16 |
-| Round                     | Y          | FP32, FP16, INT8 |
+| Round                     | Y          | FP32, FP16, BF16, FP8, INT8 |
 | STFT                      | N          |
-| ScaledTanh                | Y          | FP32, FP16, INT8 |
-| Scan                      | Y          | FP32, FP16 |
-| Scatter                   | Y          | FP32, FP16, INT8, INT32, INT64 |
-| ScatterElements           | Y          | FP32, FP16, INT8, INT32, INT64 |
-| ScatterND                 | Y          | FP32, FP16, INT8, INT32, INT64 |
-| Selu                      | Y          | FP32, FP16, INT8|
+| ScaledTanh                | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Scan                      | Y          | FP32, FP16, BF16|
+| Scatter                   | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| ScatterElements           | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| ScatterND                 | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| Selu                      | Y          | FP32, FP16, BF16, FP8, INT8|
 | SequenceAt                | N          |
 | SequenceConstruct         | N          |
 | SequenceEmpty             | N          |
@@ -162,36 +165,36 @@ See below for the support matrix of ONNX operators in ONNX-TensorRT.
 | SequenceInsert            | N          |
 | SequenceLength            | N          |
 | SequenceMap               | N          |
-| Shape                     | Y          | FP32, FP16, INT32, INT64, INT8, BOOL |
-| Shrink                    | Y          | FP32, FP16, INT32, INT64 |
-| Sigmoid                   | Y          | FP32, FP16, INT8 |
-| Sign                      | Y          | FP32, FP16, INT8, INT32, INT64 |
-| Sin                       | Y          | FP32, FP16 |
-| Sinh                      | Y          | FP32, FP16 |
-| Size                      | Y          | FP32, FP16, INT32, INT64, INT8, BOOL |
-| Slice                     | Y          | FP32, FP16, INT32, INT64, INT8, BOOL | `axes` must be an initializer                                                                                                            |
-| Softmax                   | Y          | FP32, FP16 |
+| Shape                     | Y          | FP32, FP16, BF16, FP8, INT32, INT64, INT8, BOOL |
+| Shrink                    | Y          | FP32, FP16, BF16, INT32, INT64 |
+| Sigmoid                   | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Sign                      | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| Sin                       | Y          | FP32, FP16, BF16, FP8, INT8|
+| Sinh                      | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Size                      | Y          | FP32, FP16, BF16, FP8, INT32, INT64, INT8, BOOL |
+| Slice                     | Y          | FP32, FP16, BF16, FP8, INT32, INT64, INT8, BOOL | `axes` must be an initializer                                                                                                            |
+| Softmax                   | Y          | FP32, FP16, BF16, FP8, INT8|
 | SoftmaxCrossEntropyLoss   | N          |
-| Softplus                  | Y          | FP32, FP16, INT8 |
-| Softsign                  | Y          | FP32, FP16, INT8 |
-| SpaceToDepth              | Y          | FP32, FP16, INT32, INT64 |
-| Split                     | Y          | FP32, FP16, INT32, INT64, BOOL |                                                                                                          |
+| Softplus                  | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Softsign                  | Y          | FP32, FP16, BF16, FP8, INT8 |
+| SpaceToDepth              | Y          | FP32, FP16, BF16, INT32, INT64 |
+| Split                     | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |                                                                                                          |
 | SplitToSequence           | N          |
-| Sqrt                      | Y          | FP32, FP16 |
-| Squeeze                   | Y          | FP32, FP16, INT32, INT64, INT8, BOOL | `axes` must be an initializer                                                                                                            |
+| Sqrt                      | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Squeeze                   | Y          | FP32, FP16, BF16, FP8, INT32, INT64, INT8, BOOL | `axes` must be an initializer                                                                                                            |
 | StringNormalizer          | N          |
-| Sub                       | Y          | FP32, FP16, INT32, INT64 |
-| Sum                       | Y          | FP32, FP16, INT32, INT64 |
-| Tan                       | Y          | FP32, FP16 |
-| Tanh                      | Y          | FP32, FP16, INT8 |
+| Sub                       | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| Sum                       | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64 |
+| Tan                       | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Tanh                      | Y          | FP32, FP16, BF16, FP8, INT8 |
 | TfIdfVectorizer           | N          |
-| ThresholdedRelu           | Y          | FP32, FP16, INT8 |
-| Tile                      | Y          | FP32, FP16, INT32, INT64, BOOL |
-| TopK                      | Y          | FP32, FP16, INT32, INT64 |
-| Transpose                 | Y          | FP32, FP16, INT32, INT64, INT8, BOOL |
-| Trilu                     | Y          | FP32, FP16, INT32, INT64, INT8, BOOL |
+| ThresholdedRelu           | Y          | FP32, FP16, BF16, FP8, INT8 |
+| Tile                      | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
+| TopK                      | Y          | FP32, FP16, BF16, INT32, INT64 |
+| Transpose                 | Y          | FP32, FP16, BF16, FP8, INT32, INT64, INT8, BOOL |
+| Trilu                     | Y          | FP32, FP16, BF16, FP8, INT32, INT64, INT8, BOOL |
 | Unique                    | N          |
-| Unsqueeze                 | Y          | FP32, FP16, INT32, INT64, INT8, BOOL | `axes` must be a constant tensor                                                                                                         |
-| Upsample                  | Y          | FP32, FP16 |
-| Where                     | Y          | FP32, FP16, INT32, INT64, BOOL |
+| Unsqueeze                 | Y          | FP32, FP16, BF16, FP8, INT32, INT64, INT8, BOOL | `axes` must be a constant tensor                                                                                                         |
+| Upsample                  | Y          | FP32, FP16, BF16 |
+| Where                     | Y          | FP32, FP16, BF16, FP8, INT8, INT32, INT64, BOOL |
 | Xor                       | Y          | BOOL

--- a/onnx2trt.hpp
+++ b/onnx2trt.hpp
@@ -85,8 +85,8 @@ public:
     //! Returns a map of FunctionProto names : Function protos.
     virtual StringMap<::ONNX_NAMESPACE::FunctionProto>& localFunctions() = 0;
 
-    //! Return current list of local functions
-    virtual std::vector<std::string>& localFunctionStack() = 0;
+    //! Return current list of local functions and corresponding attributes
+    virtual std::vector<std::pair<std::string, StringMap<::ONNX_NAMESPACE::AttributeProto const*>>>& localFunctionStack() = 0;
 
     //! Return output names of the ONNX graph
     virtual std::vector<::ONNX_NAMESPACE::ValueInfoProto>& getGraphOutputNames() = 0;

--- a/onnx2trt_utils.hpp
+++ b/onnx2trt_utils.hpp
@@ -403,6 +403,8 @@ Status weightsToVector(TensorOrWeights weights, std::vector<WeightType>* weightV
     return Status(ErrorCode::kSUCCESS);
 }
 
+NodeImportResult staticSliceImporter(IImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, std::vector<TensorOrWeights>& inputs, nvinfer1::ITensor& data);
+
 template <typename T>
 ShapedWeights::DataType getShapedWeightsDataType()
 {
@@ -484,6 +486,9 @@ private:
 
 // Helper function to convert weightValues' type from fp16 to fp32
 float* convertFP16Data(void* weightValues, nvinfer1::Dims shape, IImporterContext* ctx);
+
+// Helper function to get fp32 representation of fp16 or fp32 weights
+float* getFP32Values(ShapedWeights const& w, IImporterContext* ctx);
 
 // Helper function to validate input types for an ONNX node
 Status notInvalidType(TensorOrWeights const& input, std::vector<std::string> const& invalidTypes);

--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 
 from . import backend
 
-__version__ = "9.0.0"
+__version__ = "9.0.1"


### PR DESCRIPTION
# TensorRT 9.0 GA Release - 2023-9-5
For more details, see the 9.0 GA release notes for the fixes since 9.0 EA.

- Added support for FP8 and BF16 datatypes.
- Fixed a bug that previously caused `If` nodes to fail import due to branch output size mismatch
- Improved support for importing ONNX Local Functions
- Updated operator documentation