### PR TITLE
ONNX-TensorRT 9.3 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 # Version information
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 9)
-set(ONNX2TRT_MINOR 2)
+set(ONNX2TRT_MINOR 3)
 set(ONNX2TRT_PATCH 0)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 ### Dependencies
 
  - [Protobuf >= 3.0.x](https://github.com/google/protobuf/releases)
- - [TensorRT 9.2](https://developer.nvidia.com/tensorrt)
- - [TensorRT 9.2 open source libaries] (https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 9.3](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 9.3 open source libaries] (https://github.com/NVIDIA/TensorRT/)
 
 ### Building
 
@@ -99,7 +99,7 @@ Refer to the link or run `polygraphy run -h` for more information on CLI options
 
 Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` files.
 
-TensorRT 9.2 supports ONNX release 1.14.0. Install it with:
+TensorRT 9.3 supports ONNX release 1.14.0. Install it with:
 
     python3 -m pip install onnx==1.14.0
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,13 @@
 
 # ONNX-TensorRT Changelog
 
-# TensorRT 9.2 GA Release - 2023-12-4
+# TensorRT 9.3 GA Release - 2024-2-8
+For more details, see the 9.3 GA release notes for the fixes since 9.2 GA.
+
+- Added native support for `INT32` and `INT64` types for `ArgMin` and `ArgMax` nodes
+- Fixed check for valid `zero_point` values in `QuantizeLinear` and `DequantizeLinear` nodes
+
+# TensorRT 9.2 GA Release - 2023-11-8
 For more details, see the 9.2 GA release notes for the fixes since 9.1 GA.
 
 - Added support for `Hardmax`

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -2,7 +2,7 @@
 
 # Supported ONNX Operators
 
-TensorRT 9.2 supports operators up to Opset 19. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md)
+TensorRT 9.3 supports operators up to Opset 19. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/master/docs/Operators.md)
 
 TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, INT32, INT64, FP8, INT8, UINT8, and BOOL
 

--- a/onnx2trt_utils.cpp
+++ b/onnx2trt_utils.cpp
@@ -66,15 +66,6 @@ NodeImportResult argMinMaxHelper(IImporterContext* ctx, const ::ONNX_NAMESPACE::
     CHECK(notInvalidType(inputs.at(0), {"UINT8"}));
     nvinfer1::ITensor* tensor = &convertToTensor(inputs.at(0), ctx);
 
-    bool needCast = tensor->getType() == nvinfer1::DataType::kINT32;
-    if (needCast)
-    {
-        LOG_WARNING(
-            "TensorRT is using FLOAT32 precision to run an INT32 ArgMax / ArgMin. Rounding errors may occur for large "
-            "integer values");
-        tensor = castHelper(ctx, tensor, nvinfer1::DataType::kFLOAT);
-    }
-
     // Get attributes.
     OnnxAttrs attrs(node, ctx);
     int32_t keepdims = attrs.get("keepdims", 1);


### PR DESCRIPTION
# TensorRT 9.3 GA Release - 2024-2-8
For more details, see the 9.3 GA release notes for the fixes since 9.2 GA.

- Added native support for `INT32` and `INT64` types for `ArgMin` and `ArgMax` nodes
- Fixed check for valid `zero_point` values in `QuantizeLinear` and `DequantizeLinear` nodes