### PR TITLE
Normalize external weights paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ cmake_minimum_required(VERSION 3.13)
 project(onnx2trt LANGUAGES CXX C)
 
 set(ONNX2TRT_ROOT ${PROJECT_SOURCE_DIR})
-# Set C++14 as standard for the whole project
-set(CMAKE_CXX_STANDARD 14)
+# Set C++17 as standard for the whole project for ONNX 1.16 support.
+set(CMAKE_CXX_STANDARD 17)
 
 # Enable compiler warnings
 if (CMAKE_COMPILER_IS_GNUCC)


### PR DESCRIPTION
Normalize external weight paths, and update C++ build version to C++17 in line with ONNX 1.16.