### PR TITLE
Remove duplicate function to fix protobuf-lite build

### DIFF
--- a/onnxProtoUtils.cpp
+++ b/onnxProtoUtils.cpp
@@ -60,15 +60,6 @@ std::string removeRepeatedDataStrings(std::string const& s)
     return oss.str();
 }
 
-std::string convertProtoToString(::google::protobuf::Message const& message)
-{
-    std::string s;
-    ::google::protobuf::TextFormat::PrintToString(message, &s);
-    removeRawDataStrings(s);
-    s = removeRepeatedDataStrings(s);
-    return s;
-}
-
 std::string onnxIRVersionAsString(int64_t irVersion)
 {
     int64_t verMajor = irVersion / 1000000;

--- a/onnxProtoUtils.hpp
+++ b/onnxProtoUtils.hpp
@@ -50,7 +50,7 @@ std::string convertProtoToString(ProtoMessage const& message)
     removeRawDataStrings(s);
     s = removeRepeatedDataStrings(s);
     return s;
-#endif
+#endif // USE_LITE_PROTOBUF
 }
 
 // Deserializes an ONNX ModelProto passed in as a protobuf::Message or a protobuf::MessageLite.


### PR DESCRIPTION
`convertProtoToString` is now a templated function in the header, so a concrete implementation with a full proto message is no longer required.