### PR TITLE
Changes for 10.3-GA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 # Version information
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 10)
-set(ONNX2TRT_MINOR 2)
+set(ONNX2TRT_MINOR 3)
 set(ONNX2TRT_PATCH 0)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 

--- a/ShapeTensor.hpp
+++ b/ShapeTensor.hpp
@@ -234,6 +234,9 @@ ShapeTensor convertTo1D(ImporterContext* ctx, const ShapeTensor& tensor);
 //! Reshape single value 1D tensor to a 0D tensor.
 ShapeTensor convertTo0D(ImporterContext* ctx, const ShapeTensor& tensor);
 
+//! Convert ShapeTensor to Dims, with bounds checking.
+nvinfer1::Dims shapeTensorToDims(const ShapeTensor& x, const char* what, int32_t minAllowed, int32_t maxAllowed);
+
 //! Add an ISliceLayer.
 nvinfer1::ISliceLayer* addSlice(ImporterContext* ctx, nvinfer1::ITensor& data, const ShapeTensor& starts,
     const ShapeTensor& sizes, const ShapeTensor& strides);

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,19 +2,26 @@
 
 # ONNX-TensorRT Changelog
 
-# TensorRT 10.2 GA Release - 2024-7-10
+# TensorRT 10.3 GA Release - 2024-8-7
+For more details, see the 10.3 GA release notes.
+
+- Added support for tensor `axes` inputs for `Slice` nodes
+- Updated `ScatterElements` importer to use an updated plugin
+
+# TensorRT 10.2 GA Release - 2024-7-10 
 For more details, see the 10.2 GA release notes.
 
 - Improved error handling with new macros and classes
 - Minor changes to op importers for `GRU` and `Squeeze`
 
-# TensorRT 10.1 GA Release - 2024-6-17
+# TensorRT 10.1 GA Release - 2024-6-10
 For more details, see the 10.1 GA release notes.
 
 - Added `supportsModelV2` API
 - Added support for `DeformConv` operation
 - Added support for `PluginV3` TensorRT Plugins
 - Marked all IParser and IParserRefitter APIs as `noexcept`
+- Shape inputs can be passed to custom ops supported by `IPluginV3`-based plugins by indicating the input indices to be interpreted as shape inputs by a node attribute named `tensorrt_plugin_shape_input_indices`.
 
 # TensorRT 10.0 GA Release - 2024-4-25
 For more details, see the 10.0 GA release notes.

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -184,7 +184,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | Sin                       | Y          | FP32, FP16, BF16 |
 | Sinh                      | Y          | FP32, FP16, BF16 |
 | Size                      | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
-| Slice                     | Y          | FP32, FP16, BF16, INT32, INT64, BOOL | `axes` must be an initializer                                                                                                            |
+| Slice                     | Y          | FP32, FP16, BF16, INT32, INT64, BOOL | 
 | Softmax                   | Y          | FP32, FP16, BF16 |
 | SoftmaxCrossEntropyLoss   | N          |
 | Softplus                  | Y          | FP32, FP16, BF16 |

--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 
 from . import backend
 
-__version__ = "10.2.0"
+__version__ = "10.3.0"


### PR DESCRIPTION
# TensorRT 10.3 GA Release - 2024-08-07
For more details, see the 10.3 GA release notes.

- Added support for tensor `axes` inputs for `Slice` nodes
- Updated `ScatterElements` importer to use an updated plugin