### PR TITLE
ONNX-TensorRT 10.6 GA Release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "third_party/onnx"]
 	path = third_party/onnx
 	url = https://github.com/onnx/onnx.git
-	branch = v1.16.0
+	branch = v1.17.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 # Version information
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 10)
-set(ONNX2TRT_MINOR 5)
+set(ONNX2TRT_MINOR 6)
 set(ONNX2TRT_PATCH 0)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 
@@ -106,6 +106,12 @@ find_path(TENSORRT_INCLUDE_DIR NvInfer.h
   PATH_SUFFIXES include)
 MESSAGE(STATUS "Found TensorRT headers at ${TENSORRT_INCLUDE_DIR}")
 
+# TensorRT Python Headers
+find_path(TENSORRT_PYTHON_INCLUDE_DIR plugin.h
+  HINTS ${TENSORRT_ROOT}
+  PATH_SUFFIXES python/include/impl)
+message(NOTICE "Found TensorRT Python headers at ${TENSORRT_PYTHON_INCLUDE_DIR}")
+
 # Output dynamic library names depends on platform:
 if (MSVC)
     set(nvonnxparser_lib_name "nvonnxparser_${ONNX2TRT_MAJOR}")
@@ -119,7 +125,7 @@ set(nvonnxparser_lib_name_static "nvonnxparser_static")
 # Importer library
 # --------------------------------
 add_library(${nvonnxparser_lib_name} SHARED ${IMPORTER_SOURCES})
-target_include_directories(${nvonnxparser_lib_name} PUBLIC ${ONNX_INCLUDE_DIRS} ${TENSORRT_INCLUDE_DIR} ${CUDA_INCLUDE_DIR})
+target_include_directories(${nvonnxparser_lib_name} PUBLIC ${ONNX_INCLUDE_DIRS} ${TENSORRT_INCLUDE_DIR} ${TENSORRT_PYTHON_INCLUDE_DIR} ${CUDA_INCLUDE_DIR})
 target_link_libraries(${nvonnxparser_lib_name} PUBLIC onnx_proto ${PROTOBUF_LIBRARY})
 set_target_properties(${nvonnxparser_lib_name} PROPERTIES
   VERSION   ${ONNX2TRT_VERSION}
@@ -131,7 +137,7 @@ set_target_properties(${nvonnxparser_lib_name} PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
 )
 add_library(${nvonnxparser_lib_name_static} STATIC ${IMPORTER_SOURCES})
-target_include_directories(${nvonnxparser_lib_name_static} PUBLIC ${ONNX_INCLUDE_DIRS} ${TENSORRT_INCLUDE_DIR} ${CUDA_INCLUDE_DIR})
+target_include_directories(${nvonnxparser_lib_name_static} PUBLIC ${ONNX_INCLUDE_DIRS} ${TENSORRT_INCLUDE_DIR} ${TENSORRT_PYTHON_INCLUDE_DIR} ${CUDA_INCLUDE_DIR})
 target_link_libraries(${nvonnxparser_lib_name_static} PUBLIC onnx_proto ${PROTOBUF_LIBRARY})
 set_target_properties(${nvonnxparser_lib_name_static} PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY "${TRT_OUT_DIR}"
@@ -143,7 +149,7 @@ set_target_properties(${nvonnxparser_lib_name_static} PROPERTIES
 # --------------------------------
 if(BUILD_ONNXIFI)
   add_library(trt_onnxify SHARED ${ONNXIFI_SOURCES})
-  target_include_directories(trt_onnxify PUBLIC ${CUDA_INCLUDE_DIR} ${ONNX_INCLUDE_DIRS} ${TENSORRT_INCLUDE_DIR})
+  target_include_directories(trt_onnxify PUBLIC ${CUDA_INCLUDE_DIR} ${ONNX_INCLUDE_DIRS} ${TENSORRT_INCLUDE_DIR} ${TENSORRT_PYTHON_INCLUDE_DIR})
   target_link_libraries(trt_onnxify PUBLIC ${nvonnxparser_lib_name_static} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 endif()
 

--- a/ConditionalHelpers.hpp
+++ b/ConditionalHelpers.hpp
@@ -18,28 +18,27 @@
 namespace onnx2trt
 {
 
-// Given a subgraph, find all of its external inputs (tensors entering the subgraph).
-// The result is returned in `subgraphInputs`, which is a map indexed by ITensor (a tensor entering the subgraph) and
-// with values indicating a set of external input indices.
-void getSubgraphInputs(std::vector<nvinfer1::ILayer*> const& newLayers,
-    std::unordered_map<nvinfer1::ITensor*, std::set<int32_t>>& subgraphInputs);
+using NodeName = std::string;
+using LayerName = std::string;
+using InputIndex = int32_t;
 
-// Given a subgraph, find all of its external outputs (tensors exiting the subgraph).
-// The result is returned in `subgraphInputs`, which is a map indexed by ITensor (a tensor exiting the subgraph) and
-// with values indicating a set of external outputs indices.
-void getSubgraphOutputs(const std::vector<nvinfer1::ILayer*>& newLayers,
-    std::unordered_map<nvinfer1::ITensor*, std::set<int32_t>>& subgraphOutputs,
-    const std::vector<std::string>& reportedOutputs);
+// A SubgraphPortsMap maps inputs' ports of each layer in an ONNX graph.
+using SubgraphPortsMap = std::unordered_map<const nvinfer1::ILayer*, std::unordered_set<InputIndex>>;
+
+// Given a subgraph, find all of its external inputs (tensors entering the subgraph).
+void getSubgraphInputs(const std::vector<nvinfer1::ILayer*>& newLayers, SubgraphPortsMap& externalInputs);
 
 // Take a snapshot of the network before and after parsing the subgraph and return a list
 // of newly added network layers.
 void importSubgraph(ImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const& subgraph,
     std::vector<nvinfer1::ILayer*>& newLayers, std::vector<TensorOrWeights>& subgraphTensors);
 
-using InputsMap = std::unordered_map<std::string, nvinfer1::IIfConditionalInputLayer*>;
+// An InputsMap tracks which IIfConditionalInputLayer we've added to a layer's inputs,
+// so that we can reuse them if needed.
+using InputsMap = std::unordered_map<LayerName, nvinfer1::IIfConditionalInputLayer*>;
 
 // Add IIfConditionalInputLayers to the inputs of the subgraph indicated by `subgraph`.
 void addIfInputLayers(ImporterContext* ctx, nvinfer1::IIfConditional* conditional, InputsMap& inputsMap,
-    const std::vector<nvinfer1::ILayer*>& newLayers);
+    const std::vector<nvinfer1::ILayer*>& newLayers, ::ONNX_NAMESPACE::NodeProto const* node);
 
 } // namespace onnx2trt

--- a/ImporterContext.hpp
+++ b/ImporterContext.hpp
@@ -138,8 +138,17 @@ class ImporterContext
     //! Map holding FunctionProtos
     StringMap<::ONNX_NAMESPACE::FunctionProto> mLocalFunctions;
 
+    //! Data type to keep track of a local function in mLocalFunctionStack.
+    //! It is a tuple of three elements: (1) function name (2) node name and (3) function attributes.
+    struct LocalFunctionMetadata
+    {
+        std::string functionName;
+        std::string nodeName;
+        StringMap<::ONNX_NAMESPACE::AttributeProto const*> attrs;
+    };
+
     //! Vector to hold current local function names and attributes
-    std::vector<std::pair<std::string, StringMap<::ONNX_NAMESPACE::AttributeProto const*>>> mLocalFunctionStack;
+    std::vector<LocalFunctionMetadata> mLocalFunctionStack;
 
     //! Vector to hold the local function names at each error
     std::vector<std::vector<std::string>> mLocalFunctionErrors;
@@ -325,7 +334,7 @@ public:
     {
         return mLocalFunctions;
     }
-    std::vector<std::pair<std::string, StringMap<::ONNX_NAMESPACE::AttributeProto const*>>>& localFunctionStack()
+    std::vector<LocalFunctionMetadata>& localFunctionStack()
     {
         return mLocalFunctionStack;
     }

--- a/OnnxAttrs.cpp
+++ b/OnnxAttrs.cpp
@@ -9,7 +9,7 @@
 
 bool isExternalAttribute(std::string const& key, onnx2trt::ImporterContext* ctx)
 {
-    return !key.empty() && !ctx->localFunctionStack().empty() && ctx->localFunctionStack().back().second.count(key);
+    return !key.empty() && !ctx->localFunctionStack().empty() && ctx->localFunctionStack().back().attrs.count(key);
 }
 
 template <>
@@ -17,7 +17,7 @@ float OnnxAttrs::get<float>(std::string const& key) const
 {
     std::string extName = this->at(key)->ref_attr_name();
     bool isExtAttr = isExternalAttribute(extName, mCtx);
-    return isExtAttr ? mCtx->localFunctionStack().back().second.at(extName)->f() : this->at(key)->f();
+    return isExtAttr ? mCtx->localFunctionStack().back().attrs.at(extName)->f() : this->at(key)->f();
 }
 
 template <>
@@ -25,7 +25,7 @@ int32_t OnnxAttrs::get<int32_t>(std::string const& key) const
 {
     std::string extName = this->at(key)->ref_attr_name();
     bool isExtAttr = isExternalAttribute(extName, mCtx);
-    return isExtAttr ? mCtx->localFunctionStack().back().second.at(extName)->i() : this->at(key)->i();
+    return isExtAttr ? mCtx->localFunctionStack().back().attrs.at(extName)->i() : this->at(key)->i();
 }
 
 template <>
@@ -33,7 +33,7 @@ int64_t OnnxAttrs::get<int64_t>(std::string const& key) const
 {
     std::string extName = this->at(key)->ref_attr_name();
     bool isExtAttr = isExternalAttribute(extName, mCtx);
-    return isExtAttr ? mCtx->localFunctionStack().back().second.at(extName)->i() : this->at(key)->i();
+    return isExtAttr ? mCtx->localFunctionStack().back().attrs.at(extName)->i() : this->at(key)->i();
 }
 
 template <>
@@ -41,7 +41,7 @@ bool OnnxAttrs::get<bool>(std::string const& key) const
 {
     std::string extName = this->at(key)->ref_attr_name();
     bool isExtAttr = isExternalAttribute(extName, mCtx);
-    int64_t value = isExtAttr ? mCtx->localFunctionStack().back().second.at(extName)->i() : this->at(key)->i();
+    int64_t value = isExtAttr ? mCtx->localFunctionStack().back().attrs.at(extName)->i() : this->at(key)->i();
     assert(value == bool(value));
     return static_cast<bool>(value);
 }
@@ -51,7 +51,7 @@ std::string OnnxAttrs::get<std::string>(std::string const& key) const
 {
     std::string extName = this->at(key)->ref_attr_name();
     bool isExtAttr = isExternalAttribute(extName, mCtx);
-    return isExtAttr ? mCtx->localFunctionStack().back().second.at(extName)->s() : this->at(key)->s();
+    return isExtAttr ? mCtx->localFunctionStack().back().attrs.at(extName)->s() : this->at(key)->s();
 }
 
 template <>
@@ -59,7 +59,7 @@ std::vector<int32_t> OnnxAttrs::get<std::vector<int32_t>>(std::string const& key
 {
     std::string extName = this->at(key)->ref_attr_name();
     bool isExtAttr = isExternalAttribute(extName, mCtx);
-    auto attr = isExtAttr ? mCtx->localFunctionStack().back().second.at(extName)->ints() : this->at(key)->ints();
+    auto attr = isExtAttr ? mCtx->localFunctionStack().back().attrs.at(extName)->ints() : this->at(key)->ints();
     return std::vector<int32_t>(attr.begin(), attr.end());
 }
 
@@ -68,7 +68,7 @@ std::vector<int64_t> OnnxAttrs::get<std::vector<int64_t>>(std::string const& key
 {
     std::string extName = this->at(key)->ref_attr_name();
     bool isExtAttr = isExternalAttribute(extName, mCtx);
-    auto attr = isExtAttr ? mCtx->localFunctionStack().back().second.at(extName)->ints() : this->at(key)->ints();
+    auto attr = isExtAttr ? mCtx->localFunctionStack().back().attrs.at(extName)->ints() : this->at(key)->ints();
     return std::vector<int64_t>(attr.begin(), attr.end());
 }
 
@@ -77,7 +77,7 @@ std::vector<float> OnnxAttrs::get<std::vector<float>>(std::string const& key) co
 {
     std::string extName = this->at(key)->ref_attr_name();
     bool isExtAttr = isExternalAttribute(extName, mCtx);
-    auto attr = isExtAttr ? mCtx->localFunctionStack().back().second.at(extName)->floats() : this->at(key)->floats();
+    auto attr = isExtAttr ? mCtx->localFunctionStack().back().attrs.at(extName)->floats() : this->at(key)->floats();
     return std::vector<float>(attr.begin(), attr.end());
 }
 
@@ -129,7 +129,7 @@ onnx2trt::ShapedWeights OnnxAttrs::get<onnx2trt::ShapedWeights>(std::string cons
     std::string extName = this->at(key)->ref_attr_name();
     bool isExtAttr = isExternalAttribute(extName, mCtx);
 
-    ::ONNX_NAMESPACE::TensorProto const& onnxTensor = isExtAttr ? mCtx->localFunctionStack().back().second.at(extName)->t() : this->at(key)->t();
+    ::ONNX_NAMESPACE::TensorProto const& onnxTensor = isExtAttr ? mCtx->localFunctionStack().back().attrs.at(extName)->t() : this->at(key)->t();
     onnx2trt::ShapedWeights weights;
     bool success = mCtx->getWeightsContext().convertOnnxWeights(onnxTensor, &weights, true);
     if (!success)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For press and other inquiries, please contact Hector Marinez at hmarinez@nvidia.
 
 ## Supported TensorRT Versions
 
-Development on the this branch is for the latest version of [TensorRT 10.5](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
+Development on the this branch is for the latest version of [TensorRT 10.6](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
 
 For previous versions of TensorRT, refer to their respective branches.
 
@@ -29,8 +29,8 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 ### Dependencies
 
  - [Protobuf >= 3.0.x](https://github.com/google/protobuf/releases)
- - [TensorRT 10.5](https://developer.nvidia.com/tensorrt)
- - [TensorRT 10.5 open source libaries] (https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 10.6](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 10.6 open source libaries] (https://github.com/NVIDIA/TensorRT/)
 
 ### Building
 
@@ -82,9 +82,9 @@ Refer to the link or run `polygraphy run -h` for more information on CLI options
 
 Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` files.
 
-TensorRT 10.5 supports ONNX release 1.16.0. Install it with:
+TensorRT 10.6 supports ONNX release 1.17.0. Install it with:
 
-    python3 -m pip install onnx==1.16.0
+    python3 -m pip install onnx==1.17.0
 
 The ONNX-TensorRT backend can be installed by running:
 

--- a/Status.hpp
+++ b/Status.hpp
@@ -83,7 +83,8 @@
         std::vector<char const*> localFunctionStackChar{};                                                             \
         for (size_t i = 0; i < stackSize; i++)                                                                         \
         {                                                                                                              \
-            localFunctionStackString.push_back(ctx->localFunctionStack()[i].first);                                    \
+            auto const& func = ctx->localFunctionStack()[i];                                                           \
+            localFunctionStackString.push_back(func.nodeName + " (" + func.functionName + ")");                        \
         }                                                                                                              \
         ctx->localFunctionErrors().push_back(localFunctionStackString);                                                \
         for (size_t i = 0; i < stackSize; i++)                                                                         \

--- a/TensorOrWeights.cpp
+++ b/TensorOrWeights.cpp
@@ -62,9 +62,9 @@ nvinfer1::DataType TensorOrWeights::convertONNXDataType(ShapedWeights::DataType 
         case ::ONNX_NAMESPACE::TensorProto::INT64: return nvinfer1::DataType::kINT64;
         case ::ONNX_NAMESPACE::TensorProto::FLOAT8E4M3FN: return nvinfer1::DataType::kFP8;
         case ::ONNX_NAMESPACE::TensorProto::INT4: return nvinfer1::DataType::kINT4;
-    }
-    assert(false && "Unknown datatype");
-    return nvinfer1::DataType::kFLOAT;
+        }
+        assert(false && "Unknown datatype");
+        return nvinfer1::DataType::kFLOAT;
 }
 
 ShapedWeights::DataType TensorOrWeights::convertTRTDataType(nvinfer1::DataType datatype) const

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,15 @@
 
 # ONNX-TensorRT Changelog
 
+# TensorRT 10.6 GA Release - 2024-11-1
+For more details, see the 10.6 GA release notes
+
+- Updated ONNX submodule version to 1.17.0
+- Fix issue where conditional layers were incorrectly being added
+- Updated local function metadata to contain more information
+- Added support for parsing nodes with Quickly Deployable Plugins
+- Fixed handling of optional outputs
+
 # TensorRT 10.5 GA Release - 2024-10-1
 For more details, see the 10.5 GA release notes.
 

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -2,7 +2,7 @@
 
 # Supported ONNX Operators
 
-TensorRT 10.4 supports operators in the inclusive range of opset 9 to opset 20. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
+TensorRT 10.6 supports operators in the inclusive range of opset 9 to opset 22. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
 
 TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, INT32, INT64, FP8, INT8, INT4, UINT8, and BOOL
 

--- a/onnxErrorRecorder.hpp
+++ b/onnxErrorRecorder.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "NvInferRuntimeCommon.h"
+#include "NvInferRuntime.h"
 #include <atomic>
 #include <cstdint>
 #include <exception>

--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 
 from . import backend
 
-__version__ = "10.5.0"
+__version__ = "10.6.0"

--- a/toposort.hpp
+++ b/toposort.hpp
@@ -76,6 +76,11 @@ bool toposort(Container const& nodes, std::vector<size_t>* order)
         //       generalise it somehow.
         for (auto const& output : nodes.Get(i).output())
         {
+            // Empty output strings mean null outputs, do not register them.
+            if (output.empty())
+            {
+                continue;
+            }
             if (!node_map.emplace(output, i).second)
             {
                 // Output name appears more than once in graph!


### PR DESCRIPTION
# TensorRT 10.6 GA Release - 2024-11-4
For more details, see the 10.6 GA release notes

- Updated ONNX submodule version to 1.17.0
- Fix issue where conditional layers were incorrectly being added
- Updated local function metadata to contain more information
- Added support for parsing nodes with Quickly Deployable Plugins
- Fixed handling of optional outputs