### PR TITLE
ONNX-TensorRT 10.7-GA Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 # Version information
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 10)
-set(ONNX2TRT_MINOR 6)
+set(ONNX2TRT_MINOR 7)
 set(ONNX2TRT_PATCH 0)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 

--- a/ImporterContext.hpp
+++ b/ImporterContext.hpp
@@ -378,6 +378,13 @@ public:
     {
         return mBaseNameScopeStack.size();
     }
+
+    // Returns if the underlying network was created with the KSTRONGLY_TYPED flag.
+    bool const isStronglyTyped()
+    {
+        assert(mNetwork != nullptr);
+        return mNetwork->getFlag(nvinfer1::NetworkDefinitionCreationFlag::kSTRONGLY_TYPED);
+    }
 };
 
 typedef std::vector<TensorOrWeights> NodeOutputs;

--- a/NvOnnxParser.h
+++ b/NvOnnxParser.h
@@ -175,6 +175,9 @@ protected:
 //!
 //! \brief an object for parsing ONNX models into a TensorRT network definition
 //!
+//! \warning If the ONNX model has a graph output with the same name as a graph input,
+//!          the output will be renamed by prepending "__".
+//!
 //! \warning Do not inherit from this class, as doing so will break forward-compatibility of the API and ABI.
 //!
 class IParser

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For press and other inquiries, please contact Hector Marinez at hmarinez@nvidia.
 
 ## Supported TensorRT Versions
 
-Development on the this branch is for the latest version of [TensorRT 10.6](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
+Development on the this branch is for the latest version of [TensorRT 10.7](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
 
 For previous versions of TensorRT, refer to their respective branches.
 
@@ -29,8 +29,8 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 ### Dependencies
 
  - [Protobuf >= 3.0.x](https://github.com/google/protobuf/releases)
- - [TensorRT 10.6](https://developer.nvidia.com/tensorrt)
- - [TensorRT 10.6 open source libaries] (https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 10.7](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 10.7 open source libaries] (https://github.com/NVIDIA/TensorRT/)
 
 ### Building
 
@@ -82,7 +82,7 @@ Refer to the link or run `polygraphy run -h` for more information on CLI options
 
 Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` files.
 
-TensorRT 10.6 supports ONNX release 1.17.0. Install it with:
+TensorRT 10.7 supports ONNX release 1.17.0. Install it with:
 
     python3 -m pip install onnx==1.17.0
 

--- a/RNNHelpers.cpp
+++ b/RNNHelpers.cpp
@@ -24,7 +24,7 @@ nvinfer1::ITensor* addRNNInput(ImporterContext* ctx, const ::ONNX_NAMESPACE::Nod
 
     if (direction == "forward")
     {
-        iterationInput = unsqueezeTensor(ctx, node, *N_CHECK(loop->addIterator(*input)->getOutput(0)), std::vector<int>{0});
+        iterationInput = unsqueezeTensor(ctx, *N_CHECK(loop->addIterator(*input)->getOutput(0)), std::vector<int>{0});
 
         if (isRagged)
         {
@@ -38,7 +38,7 @@ nvinfer1::ITensor* addRNNInput(ImporterContext* ctx, const ::ONNX_NAMESPACE::Nod
         nvinfer1::IIteratorLayer* reverseIterator = N_CHECK(loop->addIterator(*input));
         reverseIterator->setReverse(true);
         auto reverseIteratorOutput = N_CHECK(reverseIterator->getOutput(0));
-        iterationInput = unsqueezeTensor(ctx, node, *reverseIteratorOutput, std::vector<int>{0});
+        iterationInput = unsqueezeTensor(ctx, *reverseIteratorOutput, std::vector<int>{0});
         if (isRagged)
         {
             nvinfer1::ITensor* seqLens = &convertToTensor(inputs.at(sequenceLenIndex), ctx);
@@ -52,8 +52,8 @@ nvinfer1::ITensor* addRNNInput(ImporterContext* ctx, const ::ONNX_NAMESPACE::Nod
         nvinfer1::IIteratorLayer* reverse = N_CHECK(loop->addIterator(*input));
         reverse->setReverse(true);
 
-        auto forwardInput = unsqueezeTensor(ctx, node, *N_CHECK(forward->getOutput(0)), std::vector<int>{0});
-        auto reverseInput = unsqueezeTensor(ctx, node, *N_CHECK(reverse->getOutput(0)), std::vector<int>{0});
+        auto forwardInput = unsqueezeTensor(ctx, *N_CHECK(forward->getOutput(0)), std::vector<int>{0});
+        auto reverseInput = unsqueezeTensor(ctx, *N_CHECK(reverse->getOutput(0)), std::vector<int>{0});
         if (isRagged)
         {
             nvinfer1::ITensor* seqLens = &convertToTensor(inputs.at(sequenceLenIndex), ctx);
@@ -165,8 +165,8 @@ nvinfer1::ITensor* getRaggedMask(ImporterContext* ctx, const ::ONNX_NAMESPACE::N
     nvinfer1::ITensor* seqMask;
     if (reverse)
     {
-        counter
-            = getElementWiseResult(ctx, *unsqueezeTensor(ctx, node, *maxLen, {0}), *counter, nvinfer1::ElementWiseOperation::kSUB);
+        counter = getElementWiseResult(
+            ctx, *unsqueezeTensor(ctx, *maxLen, {0}), *counter, nvinfer1::ElementWiseOperation::kSUB);
         seqMask = getElementWiseResult(ctx, *seqLens, *counter, nvinfer1::ElementWiseOperation::kLESS);
         seqMask = getUnaryResult(ctx, *seqMask, nvinfer1::UnaryOperation::kNOT);
     }
@@ -174,7 +174,7 @@ nvinfer1::ITensor* getRaggedMask(ImporterContext* ctx, const ::ONNX_NAMESPACE::N
     {
         seqMask = getElementWiseResult(ctx, *counter, *seqLens, nvinfer1::ElementWiseOperation::kLESS);
     }
-    return unsqueezeTensor(ctx, node, *seqMask, std::vector<int>{0, 2});
+    return unsqueezeTensor(ctx, *seqMask, std::vector<int>{0, 2});
 }
 
 } // namespace onnx2trt

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,13 @@
 
 # ONNX-TensorRT Changelog
 
+# TensorRT 10.7 GA Release - 2024-12-3
+For more details, see the 10.7 GA release notes
+
+- Now prioritizes using plugins over local functions when a corresponding plugin is available in the registry
+- Added dynamic axes support for `Squeeze` and `Unsqueeze` operations
+- Added support for parsing mixed-precision `BatchNormalization` nodes in strongly-typed mode
+
 # TensorRT 10.6 GA Release - 2024-11-1
 For more details, see the 10.6 GA release notes
 

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -2,7 +2,7 @@
 
 # Supported ONNX Operators
 
-TensorRT 10.6 supports operators in the inclusive range of opset 9 to opset 22. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
+TensorRT 10.7 supports operators in the inclusive range of opset 9 to opset 22. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
 
 TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, INT32, INT64, FP8, INT8, INT4, UINT8, and BOOL
 
@@ -193,7 +193,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | Split                     | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |                                                                                                          |
 | SplitToSequence           | N          |
 | Sqrt                      | Y          | FP32, FP16, BF16 |
-| Squeeze                   | Y          | FP32, FP16, BF16, INT32, INT64, BOOL | `axes` must be an initializer                                                                                                            |
+| Squeeze                   | Y          | FP32, FP16, BF16, INT32, INT64, BOOL | `axes` must be resolvable to a constant.                    |
 | StringConcat              | N          |
 | StringNormalizer          | N          |
 | StringSplit               | N          |
@@ -208,7 +208,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | Transpose                 | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
 | Trilu                     | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
 | Unique                    | N          |
-| Unsqueeze                 | Y          | FP32, FP16, BF16, INT32, INT64, BOOL | `axes` must be a constant tensor                                                                                                         |
+| Unsqueeze                 | Y          | FP32, FP16, BF16, INT32, INT64, BOOL | `axes` must be resolvable to a constant.                       |
 | Upsample                  | Y          | FP32, FP16, BF16 |
 | Where                     | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
 | Xor                       | Y          | BOOL

--- a/importerUtils.hpp
+++ b/importerUtils.hpp
@@ -165,6 +165,9 @@ nvinfer1::ITensor& convertToTensor(TensorOrWeights& input, ImporterContext* ctx)
 // Helper function to convert a ShapedWeights object into a scalar
 nvinfer1::ITensor* convertToScalar(TensorOrWeights& input, ImporterContext* ctx);
 
+// Helper function to convert a scalar into a vector.
+nvinfer1::ITensor* convertScalarToVector(ImporterContext* ctx, nvinfer1::ITensor* input);
+
 // Helper function to provide a ceiling-rounding division between two integers
 int divCeil(int n, int d);
 
@@ -302,8 +305,7 @@ nvinfer1::ITensor* sliceAcrossAxis(
     ImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node, nvinfer1::ITensor* data, int32_t const axis);
 
 // Helper function to squeeze a tensor on a given set of axes
-nvinfer1::ITensor* squeezeTensor(ImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node,
-    nvinfer1::ITensor& tensor, std::vector<int32_t> const& axes, bool regLayer = false);
+nvinfer1::ITensor* squeezeTensor(ImporterContext* ctx, nvinfer1::ITensor& tensor, std::vector<int32_t> const& axes);
 
 // Helper function to transpose a tensor given a permutation
 nvinfer1::ITensor* transposeTensor(ImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node,
@@ -316,8 +318,7 @@ NodeOutputs unaryHelper(ImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto&
     TensorOrWeights& input, nvinfer1::UnaryOperation op);
 
 // Helper function to unsqueeze tensors on a given set of axes
-nvinfer1::ITensor* unsqueezeTensor(ImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node,
-    nvinfer1::ITensor& tensor, std::vector<int32_t> const& axes, bool regLayer = false);
+nvinfer1::ITensor* unsqueezeTensor(ImporterContext* ctx, nvinfer1::ITensor& tensor, std::vector<int32_t> const& axes);
 
 // Helper function to calculate and return the expected output shape of a resize given the resize scale weights or scale
 // tensor.

--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 
 from . import backend
 
-__version__ = "10.6.0"
+__version__ = "10.7.0"


### PR DESCRIPTION
# TensorRT 10.7 GA Release
For more details, see the [10.7 GA release notes](https://docs.nvidia.com/deeplearning/tensorrt/release-notes/index.html)

- Now prioritizes using plugins over local functions when a corresponding plugin is available in the registry
- Added dynamic axes support for `Squeeze` and `Unsqueeze` operations
- Added support for parsing mixed-precision `BatchNormalization` nodes in strongly-typed mode