### PR TITLE
ONNX-TensorRT 10.8-GA Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For press and other inquiries, please contact Hector Marinez at hmarinez@nvidia.
 
 ## Supported TensorRT Versions
 
-Development on the this branch is for the latest version of [TensorRT 10.7](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
+Development on the this branch is for the latest version of [TensorRT 10.8](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
 
 For previous versions of TensorRT, refer to their respective branches.
 
@@ -29,8 +29,8 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 ### Dependencies
 
  - [Protobuf >= 3.0.x](https://github.com/google/protobuf/releases)
- - [TensorRT 10.7](https://developer.nvidia.com/tensorrt)
- - [TensorRT 10.7 open source libaries] (https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 10.8](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 10.8 open source libaries] (https://github.com/NVIDIA/TensorRT/)
 
 ### Building
 
@@ -82,7 +82,7 @@ Refer to the link or run `polygraphy run -h` for more information on CLI options
 
 Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` files.
 
-TensorRT 10.7 supports ONNX release 1.17.0. Install it with:
+TensorRT 10.8 supports ONNX release 1.17.0. Install it with:
 
     python3 -m pip install onnx==1.17.0
 

--- a/Status.hpp
+++ b/Status.hpp
@@ -204,6 +204,7 @@ static std::ostream& operator<<(std::ostream& stream, nvinfer1::DataType const& 
     case nvinfer1::DataType::kBOOL: return stream << "bool";
     case nvinfer1::DataType::kFP8: return stream << "float8";
     case nvinfer1::DataType::kINT4: return stream << "int4";
+    case nvinfer1::DataType::kFP4: return stream << "fp4";
 
     default: throw std::runtime_error("Unknown dtype");
     }

--- a/TensorOrWeights.cpp
+++ b/TensorOrWeights.cpp
@@ -24,6 +24,7 @@ std::string TensorOrWeights::getType() const
         case nvinfer1::DataType::kBOOL: return "BOOL";
         case nvinfer1::DataType::kFP8: return "FP8";
         case nvinfer1::DataType::kINT4: return "INT4";
+        case nvinfer1::DataType::kFP4: return "FP4";
         }
     }
     else
@@ -42,6 +43,7 @@ std::string TensorOrWeights::getType() const
         case ::ONNX_NAMESPACE::TensorProto::INT64: return "INT64";
         case ::ONNX_NAMESPACE::TensorProto::FLOAT8E4M3FN: return "FP8";
         case ::ONNX_NAMESPACE::TensorProto::INT4: return "INT4";
+        case ::ONNX_NAMESPACE::TensorProto::FLOAT4E2M1: return "FP4";
         }
     }
     return "UNKNOWN TYPE";
@@ -62,6 +64,7 @@ nvinfer1::DataType TensorOrWeights::convertONNXDataType(ShapedWeights::DataType 
         case ::ONNX_NAMESPACE::TensorProto::INT64: return nvinfer1::DataType::kINT64;
         case ::ONNX_NAMESPACE::TensorProto::FLOAT8E4M3FN: return nvinfer1::DataType::kFP8;
         case ::ONNX_NAMESPACE::TensorProto::INT4: return nvinfer1::DataType::kINT4;
+        case ::ONNX_NAMESPACE::TensorProto::FLOAT4E2M1: return nvinfer1::DataType::kFP4;
         }
         assert(false && "Unknown datatype");
         return nvinfer1::DataType::kFLOAT;
@@ -81,6 +84,7 @@ ShapedWeights::DataType TensorOrWeights::convertTRTDataType(nvinfer1::DataType d
         case nvinfer1::DataType::kINT64: return ::ONNX_NAMESPACE::TensorProto::INT64;
         case nvinfer1::DataType::kFP8: return ::ONNX_NAMESPACE::TensorProto::FLOAT8E4M3FN;
         case nvinfer1::DataType::kINT4: return ::ONNX_NAMESPACE::TensorProto::INT4;
+        case nvinfer1::DataType::kFP4: return ::ONNX_NAMESPACE::TensorProto::FLOAT4E2M1;
         }
         assert(false && "Unknown datatype");
         return ::ONNX_NAMESPACE::TensorProto::FLOAT;

--- a/WeightsContext.cpp
+++ b/WeightsContext.cpp
@@ -356,7 +356,7 @@ bool WeightsContext::convertOnnxWeights(
     else if (onnxDtype == ::ONNX_NAMESPACE::TensorProto::INT32 || onnxDtype == ::ONNX_NAMESPACE::TensorProto::INT64
         || onnxDtype == ::ONNX_NAMESPACE::TensorProto::FLOAT16 || onnxDtype == ::ONNX_NAMESPACE::TensorProto::BFLOAT16
         || onnxDtype == ::ONNX_NAMESPACE::TensorProto::INT8 || onnxDtype == ::ONNX_NAMESPACE::TensorProto::BOOL
-        || onnxDtype == ::ONNX_NAMESPACE::TensorProto::INT4)
+        || onnxDtype == ::ONNX_NAMESPACE::TensorProto::INT4 || onnxDtype == ::ONNX_NAMESPACE::TensorProto::FLOAT4E2M1)
     {
         if (onnxTensor.raw_data().size() > 0)
         {
@@ -399,6 +399,8 @@ bool WeightsContext::convertOnnxWeights(
                 break;
             case ::ONNX_NAMESPACE::TensorProto::INT4:
                 // int4 data is packed, each int32 element contains one byte (two int4 nibbles)
+            case ::ONNX_NAMESPACE::TensorProto::FLOAT4E2M1:
+                // int4/fp4 data is packed, each int32 element contains one byte (two int4/fp4 nibbles)
                 nbytes = onnxTensor.int32_data().size();
                 dataPtr = convertPackedInt32Data(onnxTensor.int32_data().data(), shape, nbytes, onnxDtype);
                 break;

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,15 @@
 
 # ONNX-TensorRT Changelog
 
-# TensorRT 10.7 GA Release - 2024-12-3
+# TensorRT 10.8 GA Release - 2025-1-23
+For more details, see the 10.8 GA release notes
+
+- Added support for `FLOAT4E2M1` types for quantized networks
+- Added support for dynamic axes and improved performance of `CumSum` operations
+- Fixed the import of local functions when their input tensor names aliased one from an outside scope
+- Added support for `Pow` ops with integer-typed exponent values
+
+# TensorRT 10.7 GA Release - 2024-11-26
 For more details, see the 10.7 GA release notes
 
 - Now prioritizes using plugins over local functions when a corresponding plugin is available in the registry

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,7 @@
 
 # ONNX-TensorRT Changelog
 
-# TensorRT 10.8 GA Release - 2025-1-23
+# TensorRT 10.8 GA Release - 2025-1-30
 For more details, see the 10.8 GA release notes
 
 - Added support for `FLOAT4E2M1` types for quantized networks

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -2,13 +2,13 @@
 
 # Supported ONNX Operators
 
-TensorRT 10.7 supports operators in the inclusive range of opset 9 to opset 22. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
+TensorRT 10.8 supports operators in the inclusive range of opset 9 to opset 22. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
 
-TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, INT32, INT64, FP8, INT8, INT4, UINT8, and BOOL
+TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, FP8, FP4, INT32, INT64, INT8, INT4, UINT8, and BOOL
 
 > Note: There is limited support for DOUBLE type. TensorRT will attempt to cast DOUBLE down to FLOAT, clamping values to `+-FLT_MAX` if necessary.
 
-> Note: INT8, INT4, and FP8 are treated as `Quantized Types` in TensorRT, where support is available only through quantization from a floating-point type with higher precision. See [section 7.4.2](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#qat-models-work) of the developer guide for more information.
+> Note: INT8, INT4, FP8 and FP4 are treated as `Quantized Types` in TensorRT, where support is available only through quantization from a floating-point type with higher precision. See [section 7.4.2](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#qat-models-work) of the developer guide for more information.
 
 > Note: UINT8 is only supported as network input or output tensor types.
 
@@ -47,22 +47,22 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | Compress                  | N          |
 | Concat                    | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
 | ConcatFromSequence        | N          |
-| Constant                  | Y          | FP32, FP16, BF16, INT32, INT64, BOOL | `sparse_value`, `value_string`, and `value_strings` attributes are unsupported.
-| ConstantOfShape           | Y          | FP32, FP16, BF16, INT32, INF64, BOOL |
+| Constant                  | Y          | FP32, FP16, BF16, FP8, FP4, INT4, INT32, INT64, BOOL | `sparse_value`, `value_string`, and `value_strings` attributes are unsupported.
+| ConstantOfShape           | Y          | FP32, FP16, BF16, FP8, FP4, INT4, INT32, INF64, BOOL |
 | Conv                      | Y          | FP32, FP16, BF16 |
 | ConvInteger               | N          |
 | ConvTranspose             | Y          | FP32, FP16, BF16 |
 | Cos                       | Y          | FP32, FP16, BF16 |
 | Cosh                      | Y          | FP32, FP16, BF16 |
-| CumSum                    | Y          | FP32, FP16, BF16 | `axis` must be an initializer                                                                                                            |
+| CumSum                    | Y          | FP32, FP16, BF16 | `axis` must be a build-time constant                                                                                                     |
 | DFT                       | N          |
 | DeformConv                | Y          | FP32, FP16 | `input` must have 1D or 2D spatial dimensions. `pads` for the beginning and end along each spatial axis must be the same
 | DepthToSpace              | Y          | FP32, FP16, BF16, INT32, INT64 |
-| DequantizeLinear          | Y          | INT8, FP8, INT4 | `x_zero_point` must be zero                                                                                    |
+| DequantizeLinear          | Y          | INT8, FP8, FP4, INT4 | `x_zero_point` must be zero                                                                                    |
 | Det                       | N          |
 | Div                       | Y          | FP32, FP16, BF16, INT32, INT64 |
 | Dropout                   | Y          | FP32, FP16, BF16 | `is_traning` must be an initializer and evaluate to False.
-| DynamicQuantizeLinear     | N          |
+| DynamicQuantizeLinear     | N          | Not supported. TensorRT's IDynamicQuantize can be composed from ONNX operators in the form of a model local function.
 | Einsum                    | Y          | FP32, FP16, BF16 |
 | Elu                       | Y          | FP32, FP16, BF16 |
 | Equal                     | Y          | FP32, FP16, BF16, INT32, INT64 |

--- a/importerUtils.hpp
+++ b/importerUtils.hpp
@@ -250,13 +250,14 @@ nvinfer1::IPluginCreatorInterface* importPluginCreator(ImporterContext* ctx, std
     std::string const& pluginVersion, std::string const& pluginNamespace = kTRT_STD_PLUGIN_NAMESPACE);
 
 // Helper function to get a plugin from the PluginRegistry
-std::unique_ptr<nvinfer1::IPluginV2, PluginDeleter> createPlugin(std::string const& name,
-    std::string const& pluginNamespace, nvinfer1::IPluginCreator* pluginCreator,
-    std::vector<nvinfer1::PluginField> const& pluginFields);
+std::unique_ptr<nvinfer1::IPluginV2, PluginDeleter> createPlugin(ImporterContext* ctx,
+    ::ONNX_NAMESPACE::NodeProto const& node, std::string const& name, std::string const& pluginNamespace,
+    nvinfer1::IPluginCreator* pluginCreator, std::vector<nvinfer1::PluginField> const& pluginFields);
 
 // Helper function to get a V3 plugin from the PluginRegistry
-std::unique_ptr<nvinfer1::IPluginV3> createPlugin(std::string const& name, std::string const& pluginNamespace,
-    nvinfer1::IPluginCreatorInterface* pluginCreator, std::vector<nvinfer1::PluginField> const& pluginFields);
+std::unique_ptr<nvinfer1::IPluginV3> createPlugin(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node,
+    std::string const& name, std::string const& pluginNamespace, nvinfer1::IPluginCreatorInterface* pluginCreator,
+    std::vector<nvinfer1::PluginField> const& pluginFields);
 
 // Helper function to return the identity of a TensorOrWeights
 TensorOrWeights identity(ImporterContext* ctx, TensorOrWeights input);

--- a/onnxOpCheckers.cpp
+++ b/onnxOpCheckers.cpp
@@ -269,6 +269,7 @@ DEFINE_OP_EMPTY_CHECKER(TRT_INT4QuantizeLinear)
 
 DEFINE_OP_EMPTY_CHECKER(TRT_INT4DequantizeLinear)
 
+DEFINE_OP_EMPTY_CHECKER(TRT_FP4DynamicQuantize)
 
 DECLARE_OP_CHECKER(Mul);
 
@@ -526,7 +527,12 @@ DEFINE_OP_EMPTY_CHECKER(Pad)
 
 DEFINE_OP_EMPTY_CHECKER(ParametricSoftplus)
 
-DEFINE_OP_EMPTY_CHECKER(Pow)
+DEFINE_OP_CHECKER(Pow)
+{
+    int32_t const nbInputs = node.input().size();
+    STATIC_CHECK(
+        nbInputs == 2 && "POW operator expects two inputs!", ErrorCode::kINVALID_NODE, node, errors, nodeIndex);
+}
 
 DEFINE_OP_EMPTY_CHECKER(PRelu)
 

--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 
 from . import backend
 
-__version__ = "10.7.0"
+__version__ = "10.8.0"

--- a/weightUtils.cpp
+++ b/weightUtils.cpp
@@ -37,6 +37,7 @@ char const* getDtypeName(int32_t onnxDtype)
     case ::ONNX_NAMESPACE::TensorProto::UINT64: return "UINT64";
     case ::ONNX_NAMESPACE::TensorProto::COMPLEX64: return "COMPLEX64";
     case ::ONNX_NAMESPACE::TensorProto::COMPLEX128: return "COMPLEX128";
+    case ::ONNX_NAMESPACE::TensorProto::FLOAT4E2M1: return "FLOAT4E2M1";
     default: return "<UNKNOWN>";
     }
 }
@@ -63,6 +64,7 @@ int32_t getDtypeSizeBits(int32_t onnxDtype)
     case ::ONNX_NAMESPACE::TensorProto::INT64: return 64;
     case ::ONNX_NAMESPACE::TensorProto::FLOAT8E4M3FN: return 8;
     case ::ONNX_NAMESPACE::TensorProto::INT4: return 4;
+    case ::ONNX_NAMESPACE::TensorProto::FLOAT4E2M1: return 4;
     default: return -1;
     }
 }
@@ -71,8 +73,9 @@ size_t getTensorOrWeightsSizeBytes(int64_t count, int32_t onnxDtype)
 {
 
     int32_t dTypeSize = getDtypeSizeBits(onnxDtype);
-    
-    if (dTypeSize == -1 || static_cast<size_t>(count) > std::numeric_limits<size_t>::max() / static_cast<size_t>(dTypeSize))
+
+    if (dTypeSize == -1
+        || static_cast<size_t>(count) > std::numeric_limits<size_t>::max() / static_cast<size_t>(dTypeSize))
     {
         throw std::runtime_error("Size of weights exceeds maximum!");
     }
@@ -82,7 +85,8 @@ size_t getTensorOrWeightsSizeBytes(int64_t count, int32_t onnxDtype)
     {
         // This is a specific implementation to INT4, since this is currently the only sub-byte data type
         // we're supporting. Different data-types may have different padding.
-        assert(onnxDtype == ::ONNX_NAMESPACE::TensorProto::INT4);
+        assert(
+            onnxDtype == ::ONNX_NAMESPACE::TensorProto::INT4 || onnxDtype == ::ONNX_NAMESPACE::TensorProto::FLOAT4E2M1);
         sizeInBits += 4;
     }
     assert(sizeInBits % 8 == 0);


### PR DESCRIPTION
For more details, see the 10.8 GA release notes

- Added support for `FLOAT4E2M1` types for quantized networks
- Added support for dynamic axes and improved performance of `CumSum` operations
- Fixed the import of local functions when their input tensor names aliased one from an outside scope
- Added support for `Pow` ops with integer-typed exponent values