### PR TITLE
ONNX-TensorRT 10.9-GA Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 # Version information
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 10)
-set(ONNX2TRT_MINOR 7)
+set(ONNX2TRT_MINOR 9)
 set(ONNX2TRT_PATCH 0)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 

--- a/ModelRefitter.hpp
+++ b/ModelRefitter.hpp
@@ -93,7 +93,7 @@ public:
     {
         ONNXTRT_TRY
         {
-            return &mErrors.at(index);
+            return (index >= 0 && index < mErrors.size()) ? &mErrors.at(index) : nullptr;
         }
         ONNXTRT_CATCH_LOG(mLogger)
         return nullptr;

--- a/NvOnnxParser.h
+++ b/NvOnnxParser.h
@@ -301,7 +301,7 @@ public:
     //!
     //! The flags are listed in the OnnxParserFlag enum.
     //!
-    //! \param OnnxParserFlag The flags used when parsing an ONNX model.
+    //! \param OnnxParserFlags The flags used when parsing an ONNX model.
     //!
     //! \note This function will override the previous set flags, rather than bitwise ORing the new flag.
     //!

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For press and other inquiries, please contact Hector Marinez at hmarinez@nvidia.
 
 ## Supported TensorRT Versions
 
-Development on the this branch is for the latest version of [TensorRT 10.8](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
+Development on the this branch is for the latest version of [TensorRT 10.9](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
 
 For previous versions of TensorRT, refer to their respective branches.
 
@@ -29,8 +29,8 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 ### Dependencies
 
  - [Protobuf >= 3.0.x](https://github.com/google/protobuf/releases)
- - [TensorRT 10.8](https://developer.nvidia.com/tensorrt)
- - [TensorRT 10.8 open source libaries] (https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 10.9](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 10.9 open source libraries](https://github.com/NVIDIA/TensorRT/)
 
 ### Building
 
@@ -82,7 +82,7 @@ Refer to the link or run `polygraphy run -h` for more information on CLI options
 
 Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` files.
 
-TensorRT 10.8 supports ONNX release 1.17.0. Install it with:
+TensorRT 10.9 supports ONNX release 1.17.0. Install it with:
 
     python3 -m pip install onnx==1.17.0
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,13 @@
 
 # ONNX-TensorRT Changelog
 
+# TensorRT 10.9 GA Release - 2025-3-7
+For more details, see the 10.9 GA release notes
+
+- Added support for Python AOT plugins
+- Added support for opset 21 GroupNorm
+- Fixed support for opset 18+ ScatterND
+
 # TensorRT 10.8 GA Release - 2025-1-30
 For more details, see the 10.8 GA release notes
 
@@ -46,7 +53,7 @@ For more details, see the 10.3 GA release notes.
 - Added support for tensor `axes` inputs for `Slice` nodes
 - Updated `ScatterElements` importer to use an updated plugin
 
-# TensorRT 10.2 GA Release - 2024-7-10 
+# TensorRT 10.2 GA Release - 2024-7-10
 For more details, see the 10.2 GA release notes.
 
 - Improved error handling with new macros and classes
@@ -94,7 +101,7 @@ For more details, see the 9.2 GA release notes for the fixes since 9.1 GA.
 For more details, see the 9.1 GA release notes for the fixes since 9.0 GA.
 
 - Added new `ErrorCode` enums to improve error logging
-- Added new members to `IParserError` to improve error logging 
+- Added new members to `IParserError` to improve error logging
 - Added static checkers when parsing nodes, resulting better reporting of errors
 
 # TensorRT 9.0 GA Release - 2023-9-5
@@ -108,7 +115,7 @@ For more details, see the 9.0 GA release notes for the fixes since 9.0 EA.
 For more details, see the 9.0 EA release notes for the fixes since 8.6 GA.
 
 - Added support for INT64 data type. The ONNX parser no longer automatically casts INT64 to INT32.
-- Added support for ONNX local functions when parsing ONNX models with the ONNX parser. 
+- Added support for ONNX local functions when parsing ONNX models with the ONNX parser.
 - Breaking API Change: In TensorRT 9.0, due to the introduction of INT64 as a supported data type, ONNX models with INT64 I/O require INT64 bindings. Note that prior to this release, such models required INT32 bindings.
 - Updated ONNX submodule to v1.14.0.
 
@@ -135,7 +142,7 @@ For more details, see the 8.6 EA release notes for new features added in TensorR
 
 ## Changed
 
-- All cast operations will now use the new `CastLayer` over the pervious `IdentityLayer`. 
+- All cast operations will now use the new `CastLayer` over the pervious `IdentityLayer`.
 
 # TensorRT 8.5 GA Release - 2022-11-2
 
@@ -172,7 +179,7 @@ For more details, see the 8.5 GA release notes for new features added in TensorR
 
 ## TensorRT 8.4 GA Release - 2022-6-6
 
-### Added 
+### Added
 
 For more details, see the 8.4 GA release notes for new features added in TensorRT 8.4
 
@@ -197,7 +204,7 @@ See the 8.2 EA release notes for new features added in TensorRT 8.2.
 ### Fixes
 - Removed duplicate constant layer checks that caused some performance regressions
 - Fixed expand dynamic shape calculations
-- Added parser-side checks for Scatter layer support 
+- Added parser-side checks for Scatter layer support
 
 ## TensorRT 8.2 EA Release - 2021-10-04
 ### Added

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -2,7 +2,7 @@
 
 # Supported ONNX Operators
 
-TensorRT 10.8 supports operators in the inclusive range of opset 9 to opset 22. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
+TensorRT 10.9 supports operators in the inclusive range of opset 9 to opset 22. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
 
 TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, FP8, FP4, INT32, INT64, INT8, INT4, UINT8, and BOOL
 

--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 
 from . import backend
 
-__version__ = "10.8.0"
+__version__ = "10.9.0"


### PR DESCRIPTION
For more details, see the [10.9 GA release notes](https://docs.nvidia.com/deeplearning/tensorrt/latest/getting-started/release-notes.html#tensorrt-10-9-0)

- Added support for Python AOT plugins
- Added support for opset 21 GroupNorm
- Fixed support for opset 18+ ScatterND