### PR TITLE
10.13-GA Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 # Version information
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 10)
-set(ONNX2TRT_MINOR 12)
+set(ONNX2TRT_MINOR 13)
 set(ONNX2TRT_PATCH 0)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 
@@ -37,26 +37,28 @@ set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CAC
 #--------------------------------------------------
 
 set(IMPORTER_SOURCES
-  NvOnnxParser.cpp
-  ModelImporter.cpp
-  ModelRefitter.cpp
-  onnxOpImporters.cpp
-  ImporterContext.cpp
-  importerUtils.cpp
-  ShapedWeights.cpp
-  ShapeTensor.cpp
-  LoopHelpers.cpp
-  RNNHelpers.cpp
-  OnnxAttrs.cpp
-  onnxErrorRecorder.cpp
-  ConditionalHelpers.cpp
-  bfloat16.cpp
-  onnxOpCheckers.cpp
-  onnxProtoUtils.cpp
-  weightUtils.cpp
-  WeightsContext.cpp
-  TensorOrWeights.cpp
-  errorHelpers.cpp
+    NvOnnxParser.cpp
+    ModelImporter.cpp
+    ModelRefitter.cpp
+    onnxOpImporters.cpp
+    ImporterContext.cpp
+    importerUtils.cpp
+    ShapedWeights.cpp
+    ShapeTensor.cpp
+    Status.cpp
+    LoopHelpers.cpp
+    RNNHelpers.cpp
+    OnnxAttrs.cpp
+    onnxErrorRecorder.cpp
+    ConditionalHelpers.cpp
+    bfloat16.cpp
+    onnxOpCheckers.cpp
+    onnxProtoUtils.cpp
+    TensorOrWeights.cpp
+    WeightsContext.cpp
+    WeightsContextMemoryMap.cpp
+    weightUtils.cpp
+    errorHelpers.cpp
 )
 
 if (BUILD_ONNXIFI)
@@ -70,7 +72,7 @@ set(API_TESTS_SOURCES
 
 # Find protobuf if it's not a target.
 if (NOT TARGET protobuf::libprotobuf)
-  FIND_PACKAGE(Protobuf REQUIRED)
+  FIND_PACKAGE(Protobuf)
 endif()
 
 # Set protobuf libraries between full / lite.

--- a/ConditionalHelpers.cpp
+++ b/ConditionalHelpers.cpp
@@ -55,7 +55,7 @@ void addConditionalInputLayer(ImporterContext* ctx, nvinfer1::IIfConditional* co
     }
     auto ifOutput = N_CHECK(inputLayer->getOutput(0));
     layer.setInput(inIdx, *ifOutput);
-};
+}
 
 // Take a snapshot of the network before and after parsing the subgraph and return a list
 // of newly added network layers.

--- a/ImporterContext.cpp
+++ b/ImporterContext.cpp
@@ -138,7 +138,7 @@ private:
 };
 
 //! Translates an OS-dependent DSO/DLL name into a path on the filesystem
-std::string getOSLibraryPath(std::string const& osLibName)
+inline std::string getOSLibraryPath(std::string const& osLibName)
 {
     DynamicLibrary lib{osLibName};
     return lib.getFullPath();

--- a/ImporterContext.hpp
+++ b/ImporterContext.hpp
@@ -29,7 +29,6 @@ class ErrorRecorderWrapper
 public:
     ErrorRecorderWrapper(nvinfer1::INetworkDefinition* network, nvinfer1::ILogger* logger)
         : mNetwork(network)
-        , mLogger(logger)
     {
         if (mNetwork)
         {
@@ -69,9 +68,9 @@ public:
     {
         return mOnnxErrorRecorder ? mOnnxErrorRecorder : nullptr;
     }
+
 private:
     nvinfer1::INetworkDefinition* mNetwork{nullptr};
-    nvinfer1::ILogger* mLogger{nullptr};
     ONNXParserErrorRecorder* mOnnxErrorRecorder{nullptr};
     nvinfer1::IErrorRecorder* mUserErrorRecorder{nullptr};
 };
@@ -386,7 +385,7 @@ public:
     }
 
     // Returns if the underlying network was created with the KSTRONGLY_TYPED flag.
-    bool const isStronglyTyped()
+    bool isStronglyTyped()
     {
         assert(mNetwork != nullptr);
         return mNetwork->getFlag(nvinfer1::NetworkDefinitionCreationFlag::kSTRONGLY_TYPED);

--- a/ModelImporter.cpp
+++ b/ModelImporter.cpp
@@ -102,12 +102,131 @@ static std::string makeErrorExplanation(ImporterContext* ctx, std::string const&
     return result.str();
 }
 
-//! Make error explanation from an exception.
-static std::string makeErrorExplanation(std::exception const& e, std::string const& nodeName)
+void ModelImporter::logModelInfo()
 {
-    std::ostringstream result;
-    result << "Exception occurred in - " << nodeName << "\n" << e.what();
-    return result.str();
+    auto* ctx = &mImporterCtx;
+    int64_t const opset_version = (mOnnxModel.opset_import().size() ? mOnnxModel.opset_import(0).version() : 0);
+    auto fileName = ctx->getWeightsContext().getOnnxFileLocation();
+    LOG_INFO("----------------------------------------------------------------");
+    if (!fileName.empty())
+    {
+        LOG_INFO("Input filename:   " << fileName);
+    }
+    LOG_INFO("ONNX IR version:  " << onnxIRVersionAsString(mOnnxModel.ir_version()));
+    LOG_INFO("Opset version:    " << opset_version);
+    LOG_INFO("Producer name:    " << mOnnxModel.producer_name());
+    LOG_INFO("Producer version: " << mOnnxModel.producer_version());
+    LOG_INFO("Domain:           " << mOnnxModel.domain());
+    LOG_INFO("Model version:    " << mOnnxModel.model_version());
+    LOG_INFO("Doc string:       " << mOnnxModel.doc_string());
+    LOG_INFO("----------------------------------------------------------------");
+}
+
+void ModelImporter::logErrors()
+{
+    auto* ctx = &mImporterCtx;
+    int32_t const numErrors = getNbErrors();
+    for (int32_t i = 0; i < numErrors; ++i)
+    {
+        nvonnxparser::IParserError const* error = getError(i);
+        if (error->node() != -1)
+        {
+            ::ONNX_NAMESPACE::NodeProto const& node = mOnnxModel.graph().node(error->node());
+            LOG_ERROR("While parsing node number " << error->node() << " [" << node.op_type() << " -> \""
+                                                   << node.output(0) << "\""
+                                                   << "]:");
+            LOG_ERROR("--- Begin node ---" << "\n" << node);
+            LOG_ERROR("--- End node ---");
+        }
+        LOG_ERROR("ERROR: " << error->file() << ":" << error->line() << " In function " << error->func() << ":\n"
+                            << "[" << static_cast<int>(error->code()) << "] " << error->desc());
+    }
+}
+
+void ModelImporter::reportSubgraphs()
+{
+    int32_t error_node = -1;
+    std::string input_node{};
+
+    bool allSupported = getNbErrors() == 0;
+
+    if (!allSupported)
+    {
+        int32_t nerror = getNbErrors();
+        for (int32_t i = 0; i < nerror; ++i)
+        {
+            nvonnxparser::IParserError const* error = getError(i);
+            if (error->node() != -1)
+            {
+                error_node = error->node();
+                allSupported = false;
+            }
+            // The node that we failed on is one of the input nodes (-1). Get the name of the input node
+            // that we failed on and remove all nodes that spawn out of it.
+            else
+            {
+                // Node name is extracted through error->file as all errors thrown on input nodes are wrapped
+                // around MAKE_INPUT_ERROR.
+                input_node = error->file();
+            }
+        }
+    }
+    auto* ctx = &mImporterCtx;
+    auto checkForInput = [&input_node, &ctx](::ONNX_NAMESPACE::NodeProto const& node) {
+        for (auto input : node.input())
+        {
+            if (input_node == input || ctx->loopTensors()[input_node] == input)
+            {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    bool newSubGraph(true);
+
+    // Sort and partition supported subgraphs
+    std::vector<size_t> topological_order;
+    if (!toposort(mOnnxModel.graph().node(), &topological_order))
+    {
+        LOG_ERROR("Failed to sort model topologically");
+        return;
+    }
+
+    mSubGraphSupportVector.clear();
+    for (int32_t node_idx : topological_order)
+    {
+        ::ONNX_NAMESPACE::NodeProto const& node = mOnnxModel.graph().node(node_idx);
+        // Add the node to the subgraph if:
+        //     1. It is not directly connected to an unsupported input
+        //     2. The importer function did not throw an assertion
+        bool unsupportedInput = (input_node.empty()) ? false : checkForInput(node);
+        bool unsuccessfulParse = node_idx == error_node;
+        if (!unsupportedInput && !unsuccessfulParse)
+        {
+            if (newSubGraph)
+            {
+                // If it is the beginning of a new subGraph, we start a new vector
+                mSubGraphSupportVector.emplace_back();
+                // Mark all new graphs as "unknown"
+                mSubGraphSupportVector.back().second = false;
+                newSubGraph = false;
+            }
+            // We add the new node to the last graph
+            mSubGraphSupportVector.back().first.emplace_back(node_idx);
+        }
+        else
+        {
+            // This is not a supported node, reset newSubGraph
+            newSubGraph = true;
+            allSupported = false;
+        }
+    }
+    // Only one subgraph, mark it as true.
+    if (allSupported)
+    {
+        mSubGraphSupportVector.back().second = true;
+    }
 }
 
 bool isNodeInPluginRegistry(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node)
@@ -534,119 +653,17 @@ void importLocalFunctions(ImporterContext* ctx, ::ONNX_NAMESPACE::ModelProto con
     }
 }
 
-std::pair<bool, ModelImporter::SubGraphSupportVector_t> ModelImporter::doSupportsModel(
-    void const* serialized_onnx_model, size_t serialized_onnx_model_size, char const* model_path)
-{
-    ::ONNX_NAMESPACE::ModelProto model;
-    deserializeOnnxModel(serialized_onnx_model, serialized_onnx_model_size, &model);
-
-    if (model_path)
-    {
-        mImporterCtx.setOnnxFileLocation(model_path);
-    }
-
-    bool allSupported{true};
-
-    // Parse the graph and see if we hit any parsing errors
-    allSupported = parse(serialized_onnx_model, serialized_onnx_model_size);
-
-    int32_t error_node = -1;
-    std::string input_node{};
-
-    if (!allSupported)
-    {
-        int32_t nerror = getNbErrors();
-        for (int32_t i = 0; i < nerror; ++i)
-        {
-            nvonnxparser::IParserError const* error = getError(i);
-            if (error->node() != -1)
-            {
-                error_node = error->node();
-                allSupported = false;
-            }
-            // The node that we failed on is one of the input nodes (-1). Get the name of the input node
-            // that we failed on and remove all nodes that spawn out of it.
-            else
-            {
-                // Node name is extracted through error->file as all errors thrown on input nodes are wrapped
-                // around MAKE_INPUT_ERROR.
-                input_node = error->file();
-            }
-        }
-    }
-    auto* ctx = &mImporterCtx;
-    auto checkForInput = [&input_node, &ctx](::ONNX_NAMESPACE::NodeProto const& node) {
-        for (auto input : node.input())
-        {
-            if (input_node == input || ctx->loopTensors()[input_node] == input)
-            {
-                return true;
-            }
-        }
-        return false;
-    };
-
-    bool newSubGraph(true);
-    // Sort and partition supported subgraphs
-    std::vector<size_t> topological_order;
-    if (!toposort(model.graph().node(), &topological_order))
-    {
-        LOG_VERBOSE("Failed to sort model topologically, exiting ...");
-        return std::make_pair<bool, SubGraphSupportVector_t>(false, {});
-    }
-
-    SubGraphSupportVector_t supportVector;
-    for (int32_t node_idx : topological_order)
-    {
-        ::ONNX_NAMESPACE::NodeProto const& node = model.graph().node(node_idx);
-        // Add the node to the subgraph if:
-        //     1. It is not directly connected to an unsupported input
-        //     2. The importer function did not throw an assertion
-        bool unsupportedInput = (input_node.empty()) ? false : checkForInput(node);
-        bool unsuccessfulParse = node_idx == error_node;
-        if (!unsupportedInput && !unsuccessfulParse)
-        {
-            if (newSubGraph)
-            {
-                // If it is the beginning of a new subGraph, we start a new vector
-                supportVector.emplace_back();
-                // Mark all new graphs as "unknown"
-                supportVector.back().second = false;
-                newSubGraph = false;
-            }
-            // We add the new node to the last graph
-            supportVector.back().first.emplace_back(node_idx);
-        }
-        else
-        {
-            // This is not a supported node, reset newSubGraph
-            newSubGraph = true;
-            allSupported = false;
-        }
-    }
-
-    // Only mark the subgraph as supported if there is one supported subgraph.
-    if (allSupported)
-    {
-        supportVector.back().second = true;
-    }
-    return std::make_pair(allSupported, std::move(supportVector));
-}
-
 bool ModelImporter::supportsModel(void const* serialized_onnx_model, size_t serialized_onnx_model_size,
     SubGraphCollection_t& sub_graph_collection, char const* model_path) noexcept
 {
     ONNXTRT_TRY
     {
-        std::pair<bool, SubGraphSupportVector_t> result
-            = doSupportsModel(serialized_onnx_model, serialized_onnx_model_size, model_path);
-        bool supports = result.first;
-        SubGraphSupportVector_t supportVector = result.second;
-
+        bool supports = parse(serialized_onnx_model, serialized_onnx_model_size, model_path);
+        reportSubgraphs();
         sub_graph_collection.clear();
 
         // SubGraphCollection uses size_t, while SubGraphSupportVector_t uses int64_t
-        for (const auto& pair : supportVector)
+        for (const auto& pair : mSubGraphSupportVector)
         {
             bool subgraphSupports = pair.second;
 
@@ -656,7 +673,6 @@ bool ModelImporter::supportsModel(void const* serialized_onnx_model, size_t seri
             // Create a new pair and add it to vector b
             sub_graph_collection.push_back(std::make_pair(subgraphNodesRet, subgraphSupports));
         }
-
         return supports;
     }
     ONNXTRT_CATCH_RECORD
@@ -668,14 +684,8 @@ bool ModelImporter::supportsModelV2(
 {
     ONNXTRT_TRY
     {
-        std::pair<bool, SubGraphSupportVector_t> result
-            = doSupportsModel(serialized_onnx_model, serialized_onnx_model_size, model_path);
-        bool supports = result.first;
-        SubGraphSupportVector_t supportVector = result.second;
-
-        mSubGraphSupportVector.resize(supportVector.size());
-        std::copy(supportVector.begin(), supportVector.end(), mSubGraphSupportVector.begin());
-
+        bool supports = parse(serialized_onnx_model, serialized_onnx_model_size, model_path);
+        reportSubgraphs();
         return supports;
     }
     ONNXTRT_CATCH_RECORD
@@ -699,7 +709,7 @@ bool ModelImporter::isSubgraphSupported(int64_t const index) noexcept
         std::ostringstream errorMessage;
         errorMessage << "Query index " << index
                      << " exceeds subgraph support vector (size = " << mSubGraphSupportVector.size()
-                     << "). Have you called supports_model_v2?";
+                     << "). Have you called supports_model_v2 or parse?";
         ONNXTRT_CHECK(mSubGraphSupportVector.size() > static_cast<uint64_t>(index), errorMessage.str(),
             ErrorCode::kINVALID_VALUE);
         return mSubGraphSupportVector[index].second;
@@ -715,7 +725,7 @@ int64_t* ModelImporter::getSubgraphNodes(int64_t const index, int64_t& subgraphL
         std::ostringstream errorMessage;
         errorMessage << "Query index " << index
                      << " exceeds subgraph support vector (size = " << mSubGraphSupportVector.size()
-                     << "). Have you called supports_model_v2?";
+                     << "). Have you called supports_model_v2 or parse?";
         ONNXTRT_CHECK(mSubGraphSupportVector.size() > static_cast<uint64_t>(index), errorMessage.str(),
             ErrorCode::kINVALID_VALUE);
         subgraphLength = mSubGraphSupportVector[index].first.size();
@@ -743,15 +753,7 @@ bool ModelImporter::parseWithWeightDescriptors(
 {
     ONNXTRT_TRY
     {
-        mCurrentNode = -1;
-        // TODO: This function (and its overload below) could do with some cleaning,
-        //       particularly wrt error handling.
-        // Note: We store a copy of the model so that weight arrays will persist
-        mONNXModels.emplace_back();
-        ::ONNX_NAMESPACE::ModelProto& model = mONNXModels.back();
-        deserializeOnnxModel(serialized_onnx_model, serialized_onnx_model_size, &model);
-        importModel(model);
-        return true;
+        return parse(serialized_onnx_model, serialized_onnx_model_size, nullptr);
     }
     ONNXTRT_CATCH_RECORD
 
@@ -774,26 +776,44 @@ bool ModelImporter::parse(
         {
             mImporterCtx.setOnnxFileLocation(model_path);
         }
-        return this->parseWithWeightDescriptors(serialized_onnx_model, serialized_onnx_model_size);
+
+        deserializeOnnxModel(serialized_onnx_model, serialized_onnx_model_size, &mOnnxModel);
+        try
+        {
+            this->importModel();
+        }
+        catch (OnnxTrtException& e)
+        {
+            mErrors.push_back(e.getStatus());
+        }
+        catch (std::exception& e)
+        {
+            mErrors.push_back(MAKE_ERROR(e.what(), ErrorCode::kINTERNAL_ERROR));
+        }
+
+        logErrors();
+        reportSubgraphs();
+
+        return mErrors.size() == 0;
     }
     ONNXTRT_CATCH_RECORD
 
     return false;
 }
 
-void ModelImporter::importModel(::ONNX_NAMESPACE::ModelProto const& model)
+void ModelImporter::importModel()
 {
     auto* ctx = &mImporterCtx;
     mImporterCtx.clearOpsets();
     // Add domain import limit for security reasons
     int32_t const MAX_DOMAINS = 1024;
-    ONNXTRT_CHECK(model.opset_import().size() <= MAX_DOMAINS,
+    ONNXTRT_CHECK(mOnnxModel.opset_import().size() <= MAX_DOMAINS,
         "Model contains more than 1024 domains! Parsing will halt for security reasons.",
         ErrorCode::kUNSUPPORTED_GRAPH);
-    for (int32_t i = 0; i < model.opset_import().size(); ++i)
+    for (int32_t i = 0; i < mOnnxModel.opset_import().size(); ++i)
     {
-        std::string domain = model.opset_import(i).domain();
-        int64_t version = model.opset_import(i).version();
+        std::string domain = mOnnxModel.opset_import(i).domain();
+        int64_t version = mOnnxModel.opset_import(i).version();
         // TensorRT requires an ONNX graph to be generated with at least ai.onnx version 7.
         // ONNX spec says that the default domain is either an empty string or is "ai.onnx".
         if ((domain.empty() || domain == "ai.onnx") && version < 7)
@@ -804,7 +824,10 @@ void ModelImporter::importModel(::ONNX_NAMESPACE::ModelProto const& model)
         }
         mImporterCtx.addOpset(domain, version);
     }
-    ::ONNX_NAMESPACE::GraphProto const& graph = model.graph();
+
+    logModelInfo();
+
+    ::ONNX_NAMESPACE::GraphProto const& graph = mOnnxModel.graph();
     // Create a dummy tensors so that we can reserve output names. If the output names are encountered elsewhere
     // in the graph, the ctx will know to make the names unique.
     for (::ONNX_NAMESPACE::ValueInfoProto const& output : graph.output())
@@ -813,14 +836,14 @@ void ModelImporter::importModel(::ONNX_NAMESPACE::ModelProto const& model)
     }
 
     // Import LocalFunctions
-    importLocalFunctions(&mImporterCtx, model);
+    importLocalFunctions(&mImporterCtx, mOnnxModel);
 
     // Propagate OnnxParserFlags down to the importer context.
     mImporterCtx.setFlags(getFlags());
 
     mCurrentNode = -1;
     importInputs(&mImporterCtx, graph, &mImporterCtx.tensors(), mErrors);
-    parseGraph(&mImporterCtx, graph, mErrors, model.producer_name() == "TensorRT", &mCurrentNode);
+    parseGraph(&mImporterCtx, graph, mErrors, mOnnxModel.producer_name() == "TensorRT", &mCurrentNode);
 
     mCurrentNode = -1;
     // Mark outputs defined in the ONNX model (unless tensors are user-requested)
@@ -860,7 +883,7 @@ void ModelImporter::importModel(::ONNX_NAMESPACE::ModelProto const& model)
         }
     }
 
-    if (model.producer_name() == "TensorRT")
+    if (mOnnxModel.producer_name() == "TensorRT")
     {
         // iterate over all tensors in the network and add them to "tensors" map
         StringMap<nvinfer1::ITensor*> tensors;
@@ -949,7 +972,6 @@ bool ModelImporter::parseFromFile(char const* onnxModelFile, int32_t verbosity) 
     ONNXTRT_TRY
     {
         ONNXTRT_CHECK(onnxModelFile, "Input file cannot be empty.", ErrorCode::kINVALID_VALUE);
-        auto* ctx = &mImporterCtx;
 
         // Define S_ISREG macro for Windows
 #if !defined(S_ISREG)
@@ -963,33 +985,16 @@ bool ModelImporter::parseFromFile(char const* onnxModelFile, int32_t verbosity) 
         GOOGLE_PROTOBUF_VERIFY_VERSION;
 
         // Own the ONNX model for weights to persist.
-        mONNXModels.emplace_back();
-        ::ONNX_NAMESPACE::ModelProto& onnxModel = mONNXModels.back();
-        ONNXTRT_CHECK(ParseFromFileAsBinary(&onnxModel, onnxModelFile),
+        ONNXTRT_CHECK(ParseFromFileAsBinary(&mOnnxModel, onnxModelFile),
             "Cannot read from input file: " << onnxModelFile, ErrorCode::kINVALID_VALUE);
 
         // Keep track of the absolute path to the ONNX file.
         mImporterCtx.setOnnxFileLocation(onnxModelFile);
 
-        int64_t const opset_version = (onnxModel.opset_import().size() ? onnxModel.opset_import(0).version() : 0);
-        LOG_INFO("----------------------------------------------------------------");
-        LOG_INFO("Input filename:   " << onnxModelFile);
-        LOG_INFO("ONNX IR version:  " << onnxIRVersionAsString(onnxModel.ir_version()));
-        LOG_INFO("Opset version:    " << opset_version);
-        LOG_INFO("Producer name:    " << onnxModel.producer_name());
-        LOG_INFO("Producer version: " << onnxModel.producer_version());
-        LOG_INFO("Domain:           " << onnxModel.domain());
-        LOG_INFO("Model version:    " << onnxModel.model_version());
-        LOG_INFO("Doc string:       " << onnxModel.doc_string());
-        LOG_INFO("----------------------------------------------------------------");
-
-        // Set currentNode count to -1
-        mCurrentNode = -1;
-
         // Prevent failure of importModel from early-exiting
         try
         {
-            this->importModel(onnxModel);
+            this->importModel();
         }
         catch (OnnxTrtException& e)
         {
@@ -1000,23 +1005,10 @@ bool ModelImporter::parseFromFile(char const* onnxModelFile, int32_t verbosity) 
             mErrors.push_back(MAKE_ERROR(e.what(), ErrorCode::kINTERNAL_ERROR));
         }
 
-        int32_t const numErrors = getNbErrors();
-        for (int32_t i = 0; i < numErrors; ++i)
-        {
-            nvonnxparser::IParserError const* error = getError(i);
-            if (error->node() != -1)
-            {
-                ::ONNX_NAMESPACE::NodeProto const& node = onnxModel.graph().node(error->node());
-                LOG_ERROR("While parsing node number " << error->node() << " [" << node.op_type() << " -> \""
-                                                       << node.output(0) << "\""
-                                                       << "]:");
-                LOG_ERROR("--- Begin node ---" << "\n" << node);
-                LOG_ERROR("--- End node ---");
-            }
-            LOG_ERROR("ERROR: " << error->file() << ":" << error->line() << " In function " << error->func() << ":\n"
-                                << "[" << static_cast<int>(error->code()) << "] " << error->desc());
-        }
-        return numErrors == 0;
+        logErrors();
+        reportSubgraphs();
+
+        return mErrors.size() == 0;
     }
     ONNXTRT_CATCH_RECORD
     return false;
@@ -1026,6 +1018,80 @@ char const* const* ModelImporter::getUsedVCPluginLibraries(int64_t& nbPluginLibs
 {
     nbPluginLibs = mPluginLibraryListCStr.size();
     return (nbPluginLibs > 0) ? mPluginLibraryListCStr.data() : nullptr;
+}
+
+bool ModelImporter::loadModelProto(
+    void const* serializedOnnxModel, size_t serializedOnnxModelSize, char const* modelPath) noexcept
+{
+    ONNXTRT_TRY
+    {
+        auto* ctx = &mImporterCtx;
+        if (modelPath)
+        {
+            ctx->setOnnxFileLocation(modelPath);
+        }
+
+        deserializeOnnxModel(serializedOnnxModel, serializedOnnxModelSize, &mOnnxModel);
+
+        // Populate map of initializers for loadInitializers()
+        for (::ONNX_NAMESPACE::TensorProto const& initializer : mOnnxModel.graph().initializer())
+        {
+            ctx->getWeightsContext().initializerMap().insert({initializer.name(), &initializer});
+        }
+        return true;
+    }
+    ONNXTRT_CATCH_RECORD
+    return false;
+}
+
+bool ModelImporter::loadInitializer(char const* name, void const* data, size_t size) noexcept
+{
+    ONNXTRT_TRY
+    {
+        auto* ctx = &mImporterCtx;
+        if (mOnnxModel.ByteSizeLong() == 0)
+        {
+            LOG_ERROR("An ONNX model has not been loaded yet - cannot load initializer.");
+            return false;
+        }
+
+        return ctx->getWeightsContext().loadExternalInit(name, data, size);
+    }
+    ONNXTRT_CATCH_RECORD
+    return false;
+}
+
+bool ModelImporter::parseModelProto() noexcept
+{
+    ONNXTRT_TRY
+    {
+        auto* const ctx = &mImporterCtx;
+
+        if (mOnnxModel.ByteSizeLong() == 0)
+        {
+            LOG_ERROR("An ONNX model has not been loaded yet - cannot parse empty model.");
+            return false;
+        }
+        // Prevent failure of importModel from early-exiting
+        try
+        {
+            this->importModel();
+        }
+        catch (OnnxTrtException& e)
+        {
+            mErrors.push_back(e.getStatus());
+        }
+        catch (std::exception& e)
+        {
+            mErrors.push_back(MAKE_ERROR(e.what(), ErrorCode::kINTERNAL_ERROR));
+        }
+        logErrors();
+        reportSubgraphs();
+
+        return mErrors.size() == 0;
+    }
+    ONNXTRT_CATCH_RECORD
+    return false;
 }
 
 } // namespace onnx2trt

--- a/ModelImporter.hpp
+++ b/ModelImporter.hpp
@@ -31,22 +31,31 @@ class ModelImporter : public nvonnxparser::IParser
 
 protected:
     StringMap<NodeImporter> _op_importers;
-    virtual void importModel(::ONNX_NAMESPACE::ModelProto const& model);
+    virtual void importModel();
 
 private:
     ImporterContext mImporterCtx;
     std::vector<std::string> mPluginLibraryList; // Array of strings containing plugin libs
     std::vector<char const*>
         mPluginLibraryListCStr; // Array of C-strings corresponding to the strings in mPluginLibraryList
-    std::list<::ONNX_NAMESPACE::ModelProto> mONNXModels; // Needed for ownership of weights
+    // Protobuf message representing an ONNX model. Required to keep ownership of weights.
+    ::ONNX_NAMESPACE::ModelProto mOnnxModel;
     SubGraphSupportVector_t mSubGraphSupportVector;
     int mCurrentNode;
     mutable std::vector<Status> mErrors; // Marked as mutable so that errors could be reported from const functions
     nvonnxparser::OnnxParserFlags mOnnxParserFlags{
         1U << static_cast<uint32_t>(
             nvonnxparser::OnnxParserFlag::kNATIVE_INSTANCENORM)}; // kNATIVE_INSTANCENORM is ON by default.
-    std::pair<bool, SubGraphSupportVector_t> doSupportsModel(
-        void const* serialized_onnx_model, size_t serialized_onnx_model_size, char const* model_path = nullptr);
+
+    // Log information about the model
+    void logModelInfo();
+
+    // After parse, determine the number and nodes in supported subgraphs based on the number of errors reported.
+    // Populates values for getNbSubgraphs(), isSubgraphSupported, and getSubgraphNodes.
+    void reportSubgraphs();
+
+    // After parse, log errors to the logger on the details of the node(s) that caused the error.
+    void logErrors();
 
 public:
     ModelImporter(nvinfer1::INetworkDefinition* network, nvinfer1::ILogger* logger) noexcept
@@ -143,6 +152,13 @@ public:
     bool parseFromFile(char const* onnxModelFile, int32_t verbosity) noexcept override;
 
     virtual char const* const* getUsedVCPluginLibraries(int64_t& nbPluginLibs) const noexcept override;
+
+    bool loadModelProto(void const* serializedOnnxModel, size_t serializedOnnxModelSize,
+        char const* modelPath = nullptr) noexcept override;
+
+    bool loadInitializer(char const* name, void const* data, size_t size) noexcept override;
+
+    bool parseModelProto() noexcept override;
 };
 
 } // namespace onnx2trt

--- a/ModelRefitter.cpp
+++ b/ModelRefitter.cpp
@@ -95,16 +95,16 @@ size_t ModelRefitter::batchnormWeightRefitter(
         combinedBias.at<T>(i) = biasValues[i] - meanValues[i] * combinedScale.at<T>(i);
     }
     size_t successfullyRefittedWeights = 0;
-    if (refittableWeights.count(combinedScale.name))
+    if (mRefittableWeights.count(combinedScale.name))
     {
-        refittableWeights.erase(combinedScale.name);
+        mRefittableWeights.erase(combinedScale.name);
         ONNXTRT_CHECK(mRefitter->setNamedWeights(combinedScale.name, std::move(combinedScale)),
             "Failed to set named weights", ErrorCode::kREFIT_FAILED);
         ++successfullyRefittedWeights;
     }
-    if (refittableWeights.count(combinedBias.name))
+    if (mRefittableWeights.count(combinedBias.name))
     {
-        refittableWeights.erase(combinedBias.name);
+        mRefittableWeights.erase(combinedBias.name);
         ONNXTRT_CHECK(mRefitter->setNamedWeights(combinedBias.name, std::move(combinedBias)),
             "Failed to set named weights", ErrorCode::kREFIT_FAILED);
         ++successfullyRefittedWeights;
@@ -123,12 +123,12 @@ public:
     };
 };
 
-void ModelRefitter::refitOnnxWeights(::ONNX_NAMESPACE::ModelProto const& onnx_model)
+void ModelRefitter::refitOnnxWeights()
 {
     nestedDepth = 0;
     successfullyRefittedWeights = 0;
-    size_t const numberOfWeightsToRefit = refittableWeights.size();
-    refitOnnxGraph(onnx_model.graph());
+    size_t const numberOfWeightsToRefit = mRefittableWeights.size();
+    refitOnnxGraph(mOnnxModel.graph());
     ONNXTRT_CHECK(successfullyRefittedWeights == numberOfWeightsToRefit,
         "Only successfully refitted " << successfullyRefittedWeights << " weights out of " << numberOfWeightsToRefit,
         ErrorCode::kREFIT_FAILED);
@@ -138,15 +138,15 @@ void ModelRefitter::refitOnnxGraph(::ONNX_NAMESPACE::GraphProto const& graph)
 {
     for (::ONNX_NAMESPACE::TensorProto const& initializer : graph.initializer())
     {
-        if (!refittableWeights.count(initializer.name()))
+        if (!mRefittableWeights.count(initializer.name()))
         {
             continue;
         }
         // Remove the weight name from the set as some initializers
         // might have the same name across different nested constructs (e.g. IF nodes);
         // the assumption is that those weights would have the same value
-        refittableWeights.erase(initializer.name());
-        if (refittedWeights.count(initializer.name()))
+        mRefittableWeights.erase(initializer.name());
+        if (mRefittedWeights.count(initializer.name()))
         {
             LOG_REFITTER_WARNING("Duplicate initializer name ("
                 << initializer.name() << ") was found when processing the graph (" << graph.name()
@@ -154,7 +154,7 @@ void ModelRefitter::refitOnnxGraph(::ONNX_NAMESPACE::GraphProto const& graph)
         }
         else
         {
-            refittedWeights.insert(initializer.name());
+            mRefittedWeights.insert(initializer.name());
         }
         ShapedWeights weights;
         ONNXTRT_CHECK(mWeightsContext.convertOnnxWeights(initializer, &weights, /*ownAllWeights=*/true),
@@ -210,12 +210,12 @@ void ModelRefitter::refitOnnxNode(::ONNX_NAMESPACE::NodeProto const& node, ::ONN
 
 void ModelRefitter::refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& node, std::string const& graphName)
 {
-    if (!refittableWeights.count(node.output(0)))
+    if (!mRefittableWeights.count(node.output(0)))
     {
         return;
     }
-    refittableWeights.erase(node.output(0));
-    if (refittedWeights.count(node.output(0)))
+    mRefittableWeights.erase(node.output(0));
+    if (mRefittedWeights.count(node.output(0)))
     {
         LOG_REFITTER_WARNING("Duplicate weight name name ("
             << node.output(0) << ") was found when processing the graph (" << graphName
@@ -223,7 +223,7 @@ void ModelRefitter::refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& nod
     }
     else
     {
-        refittedWeights.insert(node.output(0));
+        mRefittedWeights.insert(node.output(0));
     }
     ShapedWeights weights;
     ::ONNX_NAMESPACE::AttributeProto const& nodeAttribute = node.attribute(0);
@@ -381,10 +381,10 @@ bool ModelRefitter::refitFromBytes(
             mWeightsContext.setOnnxFileLocation(modelPath);
         }
 
-        deserializeOnnxModel(serializedOnnxModel, serializedOnnxModelSize, &onnx_model);
+        deserializeOnnxModel(serializedOnnxModel, serializedOnnxModelSize, &mOnnxModel);
 
-        refittableWeights = getRefittableWeights();
-        refitOnnxWeights(onnx_model);
+        mRefittableWeights = getRefittableWeights();
+        refitOnnxWeights();
         return true;
     }
     ONNXTRT_CATCH_LOG(mLogger)
@@ -398,11 +398,11 @@ bool ModelRefitter::refitFromFile(char const* onnxModelFile) noexcept
         // Keep track of the absolute path to the ONNX file.
         mWeightsContext.setOnnxFileLocation(onnxModelFile);
 
-        deserializeOnnxModelFile(onnxModelFile, onnx_model);
-        refittableWeights = getRefittableWeights();
-        if (!refittableWeights.empty())
+        deserializeOnnxModelFile(onnxModelFile, mOnnxModel);
+        mRefittableWeights = getRefittableWeights();
+        if (!mRefittableWeights.empty())
         {
-            refitOnnxWeights(onnx_model);
+            refitOnnxWeights();
         }
         return true;
     }
@@ -410,4 +410,62 @@ bool ModelRefitter::refitFromFile(char const* onnxModelFile) noexcept
 
     return false;
 }
+
+bool ModelRefitter::loadModelProto(
+    void const* serializedOnnxModel, size_t serializedOnnxModelSize, char const* modelPath) noexcept
+{
+    ONNXTRT_TRY
+    {
+        if (modelPath)
+        {
+            // Keep track of the absolute path to the ONNX file.
+            mWeightsContext.setOnnxFileLocation(modelPath);
+        }
+
+        deserializeOnnxModel(serializedOnnxModel, serializedOnnxModelSize, &mOnnxModel);
+
+        // Populate map of initializers for loadInitializers()
+        for (::ONNX_NAMESPACE::TensorProto const& initializer : mOnnxModel.graph().initializer())
+        {
+            mWeightsContext.initializerMap().insert({initializer.name(), &initializer});
+        }
+        return true;
+    }
+    ONNXTRT_CATCH_LOG(mLogger)
+    return false;
+}
+
+bool ModelRefitter::loadInitializer(char const* name, void const* data, size_t size) noexcept
+{
+    ONNXTRT_TRY
+    {
+        if (mOnnxModel.ByteSizeLong() == 0)
+        {
+            LOG_REFITTER_ERROR("An ONNX model has not been loaded yet - cannot load initializer.");
+            return false;
+        }
+
+        return mWeightsContext.loadExternalInit(name, data, size);
+    }
+    ONNXTRT_CATCH_LOG(mLogger)
+    return false;
+}
+
+bool ModelRefitter::refitModelProto() noexcept
+{
+    ONNXTRT_TRY
+    {
+        if (mOnnxModel.ByteSizeLong() == 0)
+        {
+            LOG_REFITTER_ERROR("An ONNX model has not been loaded yet - cannot refit an empty model.");
+            return false;
+        }
+        mRefittableWeights = getRefittableWeights();
+        refitOnnxWeights();
+        return true;
+    }
+    ONNXTRT_CATCH_LOG(mLogger)
+    return false;
+}
+
 } // namespace onnx2trt

--- a/ModelRefitter.hpp
+++ b/ModelRefitter.hpp
@@ -19,12 +19,13 @@
     {                                                                                                                  \
         std::ostringstream ss{};                                                                                       \
         if (severity <= nvinfer1::ILogger::Severity::kWARNING)                                                         \
-            ss << __FILENAME__ << ":" << __LINE__ << ": ";                                                             \
+            ss << ONNX2TRT_FILENAME << ":" << __LINE__ << ": ";                                                        \
         ss << msg;                                                                                                     \
         mLogger->log(severity, ss.str().c_str());                                                                      \
     } while (0)
 
 #define LOG_REFITTER_WARNING(msg) LOG_REFITTER(msg, nvinfer1::ILogger::Severity::kWARNING)
+#define LOG_REFITTER_ERROR(msg) LOG_REFITTER(msg, nvinfer1::ILogger::Severity::kERROR)
 
 namespace onnx2trt
 {
@@ -38,7 +39,7 @@ private:
     WeightsContext mWeightsContext;
 
     //! ONNX ModelProto object to hold ownership of ONNX weights whenever a data type conversion is not needed.
-    ::ONNX_NAMESPACE::ModelProto onnx_model;
+    ::ONNX_NAMESPACE::ModelProto mOnnxModel;
 
     //! Counter to limit the recursion depth to a set amount for nodes containing subgraphs.
     size_t nestedDepth{0};
@@ -49,8 +50,8 @@ private:
     int64_t mBatchNormWeightSuffixCounter{0};
 
     size_t successfullyRefittedWeights{};
-    std::unordered_set<std::string> refittableWeights;
-    std::unordered_set<std::string> refittedWeights;
+    std::unordered_set<std::string> mRefittableWeights;
+    std::unordered_set<std::string> mRefittedWeights;
 
     mutable std::vector<Status> mErrors;
 
@@ -63,7 +64,7 @@ private:
     size_t batchnormWeightRefitter(
         ::ONNX_NAMESPACE::NodeProto const& node, std::vector<ShapedWeights>& inputs, TConvertFunc&& f);
 
-    void refitOnnxWeights(::ONNX_NAMESPACE::ModelProto const& onnx_model);
+    void refitOnnxWeights();
     void refitOnnxGraph(::ONNX_NAMESPACE::GraphProto const& graph);
     void refitOnnxNode(::ONNX_NAMESPACE::NodeProto const& node, ::ONNX_NAMESPACE::GraphProto const& graph);
     void refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& node, std::string const& graphName);
@@ -93,7 +94,7 @@ public:
     {
         ONNXTRT_TRY
         {
-            return (index >= 0 && index < mErrors.size()) ? &mErrors.at(index) : nullptr;
+            return (index >= 0 && static_cast<size_t>(index) < mErrors.size()) ? &mErrors.at(index) : nullptr;
         }
         ONNXTRT_CATCH_LOG(mLogger)
         return nullptr;
@@ -103,6 +104,13 @@ public:
     {
         mErrors.clear();
     }
+
+    bool loadModelProto(void const* serializedOnnxModel, size_t serializedOnnxModelSize,
+        char const* modelPath = nullptr) noexcept override;
+
+    bool loadInitializer(char const* name, void const* data, size_t size) noexcept override;
+
+    bool refitModelProto() noexcept override;
 };
 
 } // namespace onnx2trt

--- a/NvOnnxParser.h
+++ b/NvOnnxParser.h
@@ -194,7 +194,7 @@ public:
     //!         it the user responsibility to intercept and report the error.
     //!         To obtain a better diagnostic, use the parseFromFile method below.
     //!
-    //! \param serialized_onnx_model Pointer to the serialized ONNX model
+    //! \param serialized_onnx_model Pointer to the serialized ONNX model. Can be freed after this function returns.
     //! \param serialized_onnx_model_size Size of the serialized ONNX model
     //!        in bytes
     //! \param model_path Absolute path to the model file for loading external weights if required
@@ -224,7 +224,7 @@ public:
     //!        If the function returns True, one can proceed to engine building
     //!        without having to call \p parse or \p parseFromFile.
     //!
-    //! \param serialized_onnx_model Pointer to the serialized ONNX model
+    //! \param serialized_onnx_model Pointer to the serialized ONNX model. Can be freed after this function returns.
     //! \param serialized_onnx_model_size Size of the serialized ONNX model
     //!        in bytes
     //! \param sub_graph_collection Container to hold supported subgraphs
@@ -234,18 +234,20 @@ public:
     TRT_DEPRECATED virtual bool supportsModel(void const* serialized_onnx_model, size_t serialized_onnx_model_size,
         SubGraphCollection_t& sub_graph_collection, const char* model_path = nullptr) noexcept = 0;
 
+    //!
+    //! [DEPRECATED] Deprecated in TensorRT 10.13. See loadInitializer().
+    //!
     //!\brief Parse a serialized ONNX model into the TensorRT network
     //! with consideration of user provided weights
     //!
-    //! \param serialized_onnx_model Pointer to the serialized ONNX model
+    //! \param serialized_onnx_model Pointer to the serialized ONNX model. Can be freed after this function returns.
     //! \param serialized_onnx_model_size Size of the serialized ONNX model
     //!        in bytes
     //! \return true if the model was parsed successfully
     //! \see getNbErrors() getError()
     //!
-    virtual bool parseWithWeightDescriptors(
-        void const* serialized_onnx_model, size_t serialized_onnx_model_size) noexcept
-        = 0;
+    TRT_DEPRECATED virtual bool parseWithWeightDescriptors(
+        void const* serialized_onnx_model, size_t serialized_onnx_model_size) noexcept = 0;
 
     //!
     //!\brief Returns whether the specified operator may be supported by the
@@ -370,7 +372,7 @@ public:
     //!            Results can be queried through \p getNbSubgraphs, \p isSubgraphSupported,
     //!            \p getSubgraphNodes.
     //!
-    //! \param serializedOnnxModel Pointer to the serialized ONNX model
+    //! \param serializedOnnxModel Pointer to the serialized ONNX model. Can be freed after this function returns.
     //! \param serializedOnnxModelSize Size of the serialized ONNX model in bytes
     //! \param modelPath Absolute path to the model file for loading external weights if required
     //! \return true if the model is supported
@@ -408,6 +410,56 @@ public:
     //! \return Pointer to the subgraph nodes array. This pointer is owned by the Parser.
     //!
     virtual int64_t* getSubgraphNodes(int64_t const index, int64_t& subgraphLength) noexcept = 0;
+
+    //!
+    //! \brief Load a serialized ONNX model into the parser. Unlike the parse(), parseFromFile(), or
+    //! parseWithWeightDescriptors() functions, this function does not immediately convert the model into a TensorRT
+    //! INetworkDefinition. Using this function allows users to provide their own initializers for the ONNX model
+    //! through the loadInitializer() function.
+    //!
+    //! Only one model can be loaded at a time. Subsequent calls to loadModelProto() will result in an error.
+    //!
+    //! To begin the conversion of the model into a TensorRT INetworkDefinition, use parseModelProto().
+    //!
+    //! \param serializedOnnxModel Pointer to the serialized ONNX model. Can be freed after this function returns.
+    //! \param serializedOnnxModelSize Size of the serialized ONNX model in bytes.
+    //! \param modelPath Absolute path to the model file for loading external weights if required.
+    //! \return true if the model was loaded successfully
+    //! \see getNbErrors() getError()
+    //!
+    virtual bool loadModelProto(
+        void const* serializedOnnxModel, size_t serializedOnnxModelSize, char const* modelPath = nullptr) noexcept = 0;
+
+    //!
+    //! \brief Prompt the ONNX parser to load an initializer with user-provided binary data.
+    //! The lifetime of the data must exceed the lifetime of the parser.
+    //!
+    //! All user-provided initializers must be provided prior to calling refitModelProto().
+    //!
+    //! This function can be called multiple times to specify the names of multiple initializers.
+    //!
+    //! Calling this function with an initializer previously specified will overwrite the previous instance.
+    //!
+    //!
+    //! This function will return false if initializer validation fails. Possible validation errors are:
+    //! * This function was called prior to loadModelProto().
+    //! * The requested initializer was not found in the model.
+    //! * The size of the data provided is different from the corresponding initializer in the model.
+    //!
+    //! \param name Name of the initializer.
+    //! \param data Binary data containing the values of the initializer.
+    //! \param size Size of the initializer in bytes.
+    //! \return true if the initializer was loaded successfully
+    //! \see loadModelProto()
+    //!
+    virtual bool loadInitializer(char const* name, void const* data, size_t size) noexcept = 0;
+
+    //! \brief Begin the parsing and conversion process of the loaded ONNX model into a TensorRT INetworkDefinition.
+    //!
+    //! \return true if conversion was successful
+    //! \see getNbErrors() getError() loadModelProto() loadModelProtoFromFile()
+    //!
+    virtual bool parseModelProto() noexcept = 0;
 };
 
 //!
@@ -470,6 +522,54 @@ public:
     virtual void clearErrors() = 0;
 
     virtual ~IParserRefitter() noexcept = default;
+
+    //!
+    //! \brief Load a serialized ONNX model into the parser. Unlike the refit(), or refitFromFile()
+    //! functions, this function does not immediately begin the refit process. Using this function
+    //! allows users to provide their own initializers for the ONNX model through the loadInitializer() function.
+    //!
+    //! Only one model can be loaded at a time. Subsequent calls to loadModelProto() will result in an error.
+    //!
+    //! To begin the refit process, use refitModelProto().
+    //!
+    //! \param serializedOnnxModel Pointer to the serialized ONNX model. Can be freed after this function returns.
+    //! \param serializedOnnxModelSize Size of the serialized ONNX model in bytes.
+    //! \param modelPath Absolute path to the model file for loading external weights if required.
+    //! \return true if the model was loaded successfully
+    //! \see getNbErrors() getError()
+    //!
+    virtual bool loadModelProto(
+        void const* serializedOnnxModel, size_t serializedOnnxModelSize, char const* modelPath = nullptr) noexcept = 0;
+
+    //!
+    //! \brief Prompt the ONNX refitter to load an initializer with user-provided binary data.
+    //! The lifetime of the data must exceed the lifetime of the refitter.
+    //!
+    //! All user-provided initializers must be provided prior to calling refitModelProto().
+    //!
+    //! This function can be called multiple times to specify the names of multiple initializers.
+    //!
+    //! Calling this function with an initializer previously specified will overwrite the previous instance.
+    //!
+    //! This function will return false if initializer validation fails. Possible validation errors are:
+    //! * This function was called prior to loadModelProto()
+    //! * The requested initializer was not found in the model.
+    //! * The size of the data provided is different from the corresponding initializer in the model.
+    //!
+    //! \param name Name of the initializer.
+    //! \param data Binary data containing the values of the initializer.
+    //! \param size Size of the initializer in bytes.
+    //! \return true if the initializer was loaded successfully
+    //! \see loadModelProto()
+    //!
+    virtual bool loadInitializer(char const* name, void const* data, size_t size) noexcept = 0;
+
+    //! \brief Begin the refit process from the loaded ONNX model.
+    //!
+    //! \return true if refit was successful
+    //! \see getNbErrors() getError() loadModelProto()
+    //!
+    virtual bool refitModelProto() noexcept = 0;
 };
 
 } // namespace nvonnxparser

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For press and other inquiries, please contact Hector Marinez at hmarinez@nvidia.
 
 ## Supported TensorRT Versions
 
-Development on the this branch is for the latest version of [TensorRT 10.12](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
+Development on the this branch is for the latest version of [TensorRT 10.13](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
 
 For previous versions of TensorRT, refer to their respective branches.
 
@@ -28,9 +28,9 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 
 ### Dependencies
 
- - [Protobuf >= 3.0.x](https://github.com/google/protobuf/releases)
- - [TensorRT 10.12](https://developer.nvidia.com/tensorrt)
- - [TensorRT 10.12 open source libraries](https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 10.13](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 10.13 open source libraries](https://github.com/NVIDIA/TensorRT/)
+ - [Protobuf >= 3.20.3 (Optional)](https://github.com/google/protobuf/releases)
 
 ### Building
 
@@ -82,7 +82,7 @@ Refer to the link or run `polygraphy run -h` for more information on CLI options
 
 Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` files.
 
-TensorRT 10.12 supports ONNX release 1.18.0. Install it with:
+TensorRT 10.13 supports ONNX release 1.18.0. Install it with:
 
     python3 -m pip install onnx==1.18.0
 

--- a/ShapedWeights.hpp
+++ b/ShapedWeights.hpp
@@ -10,6 +10,15 @@
 namespace onnx2trt
 {
 
+//!
+//! \class ShapedWeights
+//!
+//! \brief Represents ONNX weights, with built-in conversion to TensorRT's nvinfer1::Weights.
+//!
+//! One of the types in the union class TensorOrWeights.
+//! Does not own the underlying data, but is allowed to modify it. Underlying memory is allocated and freed by
+//! WeightsContext which has the same lifetime as the IParser / IParserRefitter class.
+//!
 class ShapedWeights
 {
 public:
@@ -40,14 +49,14 @@ public:
     template <typename T>
     T& at(size_t index)
     {
-        assert(values && index >= 0 && index < count());
+        assert(values && index < count());
         return static_cast<T*>(values)[index];
     }
 
     template <typename T>
     const T& at(size_t index) const
     {
-        assert(values && index >= 0 && index < count());
+        assert(values && index < count());
         return static_cast<const T*>(values)[index];
     }
 

--- a/Status.cpp
+++ b/Status.cpp
@@ -1,0 +1,50 @@
+#include "Status.hpp"
+
+namespace onnx2trt
+{
+
+template <typename T>
+std::ostream& printSequence(std::ostream& stream, const T* begin, int count)
+{
+    stream << "(";
+    if (count > 0)
+    {
+        std::copy_n(begin, count - 1, std::ostream_iterator<T>(stream, ", "));
+        stream << begin[count - 1];
+    }
+    stream << ")";
+    return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, nvinfer1::Dims const& shape)
+{
+    return printSequence(stream, shape.d, shape.nbDims);
+}
+
+std::ostream& operator<<(std::ostream& stream, nvinfer1::Permutation const& perm)
+{
+    return printSequence(stream, perm.order, nvinfer1::Dims::MAX_DIMS);
+}
+
+std::ostream& operator<<(std::ostream& stream, nvinfer1::DataType const& dtype)
+{
+    switch (dtype)
+    {
+    case nvinfer1::DataType::kFLOAT: return stream << "float32";
+    case nvinfer1::DataType::kHALF: return stream << "float16";
+    case nvinfer1::DataType::kBF16: return stream << "bfloat16";
+    case nvinfer1::DataType::kINT8: return stream << "int8";
+    case nvinfer1::DataType::kUINT8: return stream << "uint8";
+    case nvinfer1::DataType::kINT32: return stream << "int32";
+    case nvinfer1::DataType::kINT64: return stream << "int64";
+    case nvinfer1::DataType::kBOOL: return stream << "bool";
+    case nvinfer1::DataType::kFP8: return stream << "float8";
+    case nvinfer1::DataType::kE8M0: return stream << "floatE8M0";
+    case nvinfer1::DataType::kINT4: return stream << "int4";
+    case nvinfer1::DataType::kFP4: return stream << "fp4";
+
+    default: throw std::runtime_error("Unknown dtype");
+    }
+}
+
+} // namespace onnx2trt

--- a/Status.hpp
+++ b/Status.hpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <filesystem>
 #include <iterator>
 #include <sstream>
 #include <string>
@@ -22,11 +23,20 @@
 #define USE_LITE_PROTOBUF 0
 #endif // USE_LITE_PROTOBUF
 
-// Used to strip out build path information from debug prints
-#if defined(SOURCE_LENGTH)
-#define __FILENAME__ (__FILE__ + SOURCE_LENGTH)
+// Helper macro that wraps __FILE__ and returns a std::string of the filename at runtime.
+#if defined(__GLIBCXX__) && defined(__aarch64__)
+[[maybe_unused]] static std::string filename(std::string_view path)
+{
+    auto pos = path.rfind('/');
+    if (pos == std::string_view::npos)
+    {
+        return std::string(path);
+    }
+    return std::string(path.substr(pos + 1));
+}
+#define ONNX2TRT_FILENAME (filename(__FILE__))
 #else
-#define __FILENAME__ (__FILE__)
+#define ONNX2TRT_FILENAME (std::filesystem::path(__FILE__).filename().string())
 #endif
 
 // Logging macros
@@ -35,7 +45,7 @@
     {                                                                                                                  \
         std::stringstream ss{};                                                                                        \
         if (severity <= nvinfer1::ILogger::Severity::kWARNING)                                                         \
-            ss << __FILENAME__ << ":" << __LINE__ << ": ";                                                             \
+            ss << ONNX2TRT_FILENAME << ":" << __LINE__ << ": ";                                                        \
         ss << msg;                                                                                                     \
         ctx->logger().log(severity, ss.str().c_str());                                                                 \
     } while (0)
@@ -45,7 +55,7 @@
 #define LOG_WARNING(msg) LOG(msg, nvinfer1::ILogger::Severity::kWARNING)
 #define LOG_ERROR(msg) LOG(msg, nvinfer1::ILogger::Severity::kERROR)
 
-#define MAKE_ERROR(desc, code) onnx2trt::Status((code), (desc), __FILENAME__, __LINE__, __func__)
+#define MAKE_ERROR(desc, code) onnx2trt::Status((code), (desc), ONNX2TRT_FILENAME, __LINE__, __func__)
 
 #define ASSERT(condition, error_code)                                                                                  \
     do                                                                                                                 \
@@ -57,7 +67,7 @@
     } while (0)
 
 #define MAKE_NODE_ERROR(desc, code, node, index)                                                                       \
-    onnx2trt::Status((code), (desc), __FILENAME__, __LINE__, __func__, (index), (node.name()), (node.op_type()))
+    onnx2trt::Status((code), (desc), ONNX2TRT_FILENAME, __LINE__, __func__, (index), (node.name()), (node.op_type()))
 
 #define ASSERT_NODE(condition, msg, node, index, error_code)                                                           \
     do                                                                                                                 \
@@ -71,7 +81,7 @@
     } while (0)
 
 #define MAKE_STATIC_ERROR(desc, code, node, index)                                                                     \
-    onnx2trt::Status((code), (desc), __FILENAME__, __LINE__, __func__, (index), (node.name()), (node.op_type()))
+    onnx2trt::Status((code), (desc), ONNX2TRT_FILENAME, __LINE__, __func__, (index), (node.name()), (node.op_type()))
 
 #define ADD_STATIC_ERROR(desc, code, node, index, error_list)                                                          \
     do                                                                                                                 \
@@ -89,7 +99,7 @@
         {                                                                                                              \
             localFunctionStackChar.push_back(ctx->localFunctionErrors().back()[i].c_str());                            \
         }                                                                                                              \
-        error_list.push_back(onnx2trt::Status((code), (desc), __FILENAME__, __LINE__, __func__, (index),               \
+        error_list.push_back(onnx2trt::Status((code), (desc), ONNX2TRT_FILENAME, __LINE__, __func__, (index),          \
             (node.name()), (node.op_type()), localFunctionStackChar));                                                 \
     } while (0)
 
@@ -159,60 +169,17 @@ T* N_CHECK(T* inputPtr)
     return inputPtr;
 }
 
-// Overloads of operator<< on TensorRT types must be defined inside nvinfer1
-// so that argument-dependent lookup works as expected. Declared static to
-// avoid symbol clashing when statically linking with other TensorRT libraries
-namespace nvinfer1
+namespace onnx2trt
 {
 
 template <typename T>
-static std::ostream& printSequence(std::ostream& stream, const T* begin, int count)
-{
-    stream << "(";
-    if (count > 0)
-    {
-        std::copy_n(begin, count - 1, std::ostream_iterator<T>(stream, ", "));
-        stream << begin[count - 1];
-    }
-    stream << ")";
-    return stream;
-}
+std::ostream& printSequence(std::ostream& stream, const T* begin, int count);
 
-static std::ostream& operator<<(std::ostream& stream, nvinfer1::Dims const& shape)
-{
-    return printSequence(stream, shape.d, shape.nbDims);
-}
+std::ostream& operator<<(std::ostream& stream, nvinfer1::Dims const& shape);
 
-static std::ostream& operator<<(std::ostream& stream, nvinfer1::Permutation const& perm)
-{
-    return printSequence(stream, perm.order, nvinfer1::Dims::MAX_DIMS);
-}
+std::ostream& operator<<(std::ostream& stream, nvinfer1::Permutation const& perm);
 
-static std::ostream& operator<<(std::ostream& stream, nvinfer1::DataType const& dtype)
-{
-    switch (dtype)
-    {
-    case nvinfer1::DataType::kFLOAT: return stream << "float32";
-    case nvinfer1::DataType::kHALF: return stream << "float16";
-    case nvinfer1::DataType::kBF16: return stream << "bfloat16";
-    case nvinfer1::DataType::kINT8: return stream << "int8";
-    case nvinfer1::DataType::kUINT8: return stream << "uint8";
-    case nvinfer1::DataType::kINT32: return stream << "int32";
-    case nvinfer1::DataType::kINT64: return stream << "int64";
-    case nvinfer1::DataType::kBOOL: return stream << "bool";
-    case nvinfer1::DataType::kFP8: return stream << "float8";
-    case nvinfer1::DataType::kE8M0: return stream << "floatE8M0";
-    case nvinfer1::DataType::kINT4: return stream << "int4";
-    case nvinfer1::DataType::kFP4: return stream << "fp4";
-
-    default: throw std::runtime_error("Unknown dtype");
-    }
-}
-
-} // namespace nvinfer1
-
-namespace onnx2trt
-{
+std::ostream& operator<<(std::ostream& stream, nvinfer1::DataType const& dtype);
 
 using nvonnxparser::ErrorCode;
 

--- a/WeightsContext.cpp
+++ b/WeightsContext.cpp
@@ -20,6 +20,11 @@ void* WeightsContext::ownWeights(
     return reservedWeights;
 }
 
+WeightsContext::~WeightsContext()
+{
+    clearMemoryMappings();
+}
+
 int32_t* WeightsContext::convertUINT8(uint8_t const* weightValues, nvinfer1::Dims const& shape)
 {
     int64_t const nbWeights = volume(shape);
@@ -91,6 +96,28 @@ bool multiplicationWillOverflow(size_t const a, size_t const b)
     return false;
 }
 
+
+size_t getInitializerVol(google::protobuf::RepeatedField<int64_t> const& dims)
+{
+    size_t vol = 1;
+    auto nbDims = dims.size();
+    for (int32_t i = 0; i < nbDims; i++)
+    {
+        auto dimVal = dims.Get(i);
+        if (dimVal == 0)
+        {
+            vol = 0;
+            break;
+        }
+        if (vol > std::numeric_limits<size_t>::max() / dimVal)
+        {
+            return false;
+        }
+        vol = vol * dimVal;
+    }
+    return vol;
+}
+
 // Helper function to ensure that a ONNX initializer is supportable by TensorRT.
 bool validateOnnxInitializer(::ONNX_NAMESPACE::TensorProto const& onnxTensor)
 {
@@ -108,33 +135,18 @@ bool validateOnnxInitializer(::ONNX_NAMESPACE::TensorProto const& onnxTensor)
         return false;
     }
     // Validate volume is within bounds.
-    size_t vol = 1;
-    for (int32_t i = 0; i < nbDims; i++)
-    {
-        auto dimVal = onnxTensor.dims().Get(i);
-        if (dimVal == 0)
-        {
-            vol = 0;
-            break;
-        }
-        if (vol > std::numeric_limits<size_t>::max() / dimVal)
-        {
-            return false;
-        }
-        vol = vol * dimVal;
-    }
+    size_t vol = getInitializerVol(onnxTensor.dims());
     // Validate size in bytes is within bounds.
     if (vol > std::numeric_limits<size_t>::max() / typeSize)
     {
         return false;
     }
-
     return true;
 }
 
 // Function to read bytes from an external file and return the data in a buffer.
 bool WeightsContext::parseExternalWeights(
-    std::string const& file, int64_t offset, int64_t length, std::vector<char>& weightsBuf, size_t& size)
+    std::string const& file, int64_t offset, int64_t length, MemoryMapping_t& weightsRef)
 {
     auto* ctx = this; // For logging macros.
     // Accessing parent directories (i.e. ../) is not allowed. Normalize path first.
@@ -178,29 +190,37 @@ bool WeightsContext::parseExternalWeights(
         LOG_ERROR("Failed to open file: " << path);
         return false;
     }
-    std::streamsize fileSize = relPathFile.tellg();
-    relPathFile.seekg(offset, std::ios::beg);
-    int64_t weightsBufSize = length == 0 ? fileSize : length;
-    weightsBuf.resize(weightsBufSize);
-    if (!relPathFile.read(weightsBuf.data(), weightsBuf.size()))
+
+    LOG_VERBOSE("Mapping external weights file to memory: " << path);
+    auto memoryMap = mmap(path);
+
+    if (memoryMap.second <= 0)
     {
         LOG_ERROR("Failed to read weights from external file: " << path);
         return false;
     }
-    size = weightsBuf.size();
+
+    int64_t weightsSize = (length == 0) ? memoryMap.second : length;
+
+    auto* weightsPtr = static_cast<char*>(memoryMap.first) + offset;
+
+    weightsRef = std::make_pair(static_cast<void*>(weightsPtr), weightsSize);
+
     return true;
 }
 
-// Function to read data from an ONNX Tensor and move it into a ShapedWeights object. Handles external weights as well.
+// Function to read data from an ONNX Tensor and move it into a ShapedWeights object. Handles model, user-provided, and external weights.
 bool WeightsContext::convertOnnxWeights(
     ::ONNX_NAMESPACE::TensorProto const& onnxTensor, ShapedWeights* weights, bool ownAllWeights)
 {
     auto* ctx = this; // For logging macros.
 
+    std::string const initName = onnxTensor.name();
+
     // Sanity check for onnxTensors
     if (!validateOnnxInitializer(onnxTensor))
     {
-        LOG_ERROR("ONNX initializer " << onnxTensor.name() << " cannot be imported into TensorRT!");
+        LOG_ERROR("ONNX initializer " << initName << " cannot be imported into TensorRT!");
         return false;
     }
 
@@ -211,11 +231,23 @@ bool WeightsContext::convertOnnxWeights(
     nvinfer1::Dims shape{};
     shape.nbDims = onnxTensor.dims().size();
     std::copy_n(onnxTensor.dims().begin(), shape.nbDims, shape.d);
+
+    // Priority of importing weights:
+    //  1. User provided
+    //  2. External weights
+    //  3. Model weights
+    bool const userWeights = mExternalInits.count(initName);
+
+    if (userWeights)
+    {
+        LOG_VERBOSE(initName << " is a user-specified initializer");
+    }
+
     // ONNX weight values can be stored in either the TensorProto itself, or in an external file in the case
     // of large models. Check for this here.
     auto dataLocation = onnxTensor.data_location();
     // External Data
-    if (dataLocation == 1)
+    if (dataLocation == 1 && !userWeights)
     {
         std::string location{""};
         int64_t offset{0};
@@ -251,16 +283,16 @@ bool WeightsContext::convertOnnxWeights(
         }
 
         // Buffer to hold the data read from the file
-        std::vector<char> dataBuf;
+        MemoryMapping_t weightsRef;
         // Will update dataBuf and nbytes by reference.
-        if (!parseExternalWeights(location, offset, length, dataBuf, nbytes))
+        if (!parseExternalWeights(location, offset, length, weightsRef))
         {
             return false;
         }
 
         // For weights parsed from external files, createTempWeights is necessary to keep them in scope
         ShapedWeights externalWeights;
-        dataPtr = dataBuf.data();
+        dataPtr = weightsRef.first;
 
         // Cast non-native TRT types to their corresponding proxy types
         if (onnxDtype == ::ONNX_NAMESPACE::TensorProto::DOUBLE)
@@ -271,11 +303,10 @@ bool WeightsContext::convertOnnxWeights(
             onnxDtype = ::ONNX_NAMESPACE::TensorProto::FLOAT;
         }
 
-        // Create the holder for external weights.
-        externalWeights = createTempWeights(onnxDtype, shape);
+        externalWeights = ShapedWeights(onnxDtype, dataPtr, shape);
 
         // Check if the size of external weights is as expected.
-        if (externalWeights.size_bytes() != nbytes)
+        if (static_cast<int64_t>(externalWeights.size_bytes()) != weightsRef.second)
         {
             LOG_ERROR("Unexpected size for the external weights! Expected size: "
                 << externalWeights.size_bytes() << " bytes (shape = " << shape << "). Actual size: " << nbytes
@@ -283,19 +314,22 @@ bool WeightsContext::convertOnnxWeights(
             return false;
         }
 
-        // Copy the weight values into externalWeights.
-        std::memcpy(externalWeights.values, dataPtr, nbytes);
-
         *weights = externalWeights;
         return true;
     }
 
-    // Weights information is within the TensorProto itself
+    // Weights information is user provided or within the model
 
     // Cast non-native TRT types to their corresponding proxy types
     if (onnxDtype == ::ONNX_NAMESPACE::TensorProto::DOUBLE)
     {
-        if (onnxTensor.raw_data().size() > 0)
+        if (userWeights)
+        {
+            std::pair<void const*, size_t> initDesc = mExternalInits.at(initName);
+            dataPtr = convertDouble(reinterpret_cast<double const*>(initDesc.first), shape);
+            nbytes = initDesc.second / (sizeof(double) / sizeof(float));
+        }
+        else if (onnxTensor.raw_data().size() > 0)
         {
             dataPtr = convertDouble(reinterpret_cast<double const*>(onnxTensor.raw_data().data()), shape);
             nbytes = onnxTensor.raw_data().size() / (sizeof(double) / sizeof(float));
@@ -319,7 +353,13 @@ bool WeightsContext::convertOnnxWeights(
         || onnxDtype == ::ONNX_NAMESPACE::TensorProto::INT8 || onnxDtype == ::ONNX_NAMESPACE::TensorProto::BOOL
         || onnxDtype == ::ONNX_NAMESPACE::TensorProto::INT4 || onnxDtype == ::ONNX_NAMESPACE::TensorProto::FLOAT4E2M1)
     {
-        if (onnxTensor.raw_data().size() > 0)
+        if (userWeights)
+        {
+            std::pair<void const*, size_t> initDesc = mExternalInits.at(initName);
+            dataPtr = (void*) initDesc.first;
+            nbytes = initDesc.second;
+        }
+        else if (onnxTensor.raw_data().size() > 0)
         {
             dataPtr = (void*) (onnxTensor.raw_data().data());
             nbytes = onnxTensor.raw_data().size();
@@ -374,7 +414,13 @@ bool WeightsContext::convertOnnxWeights(
     }
     else if (onnxDtype == ::ONNX_NAMESPACE::TensorProto::FLOAT)
     {
-        if (onnxTensor.raw_data().size() > 0)
+        if (userWeights)
+        {
+            std::pair<void const*, size_t> initDesc = mExternalInits.at(initName);
+            dataPtr = (void*) initDesc.first;
+            nbytes = initDesc.second;
+        }
+        else if (onnxTensor.raw_data().size() > 0)
         {
             dataPtr = (void*) (onnxTensor.raw_data().data());
             nbytes = onnxTensor.raw_data().size();
@@ -396,7 +442,13 @@ bool WeightsContext::convertOnnxWeights(
     else if (onnxDtype == ::ONNX_NAMESPACE::TensorProto::FLOAT8E4M3FN
         || onnxDtype == ::ONNX_NAMESPACE::TensorProto::UINT8)
     {
-        if (onnxTensor.raw_data().size() > 0)
+        if (userWeights)
+        {
+            std::pair<void const*, size_t> initDesc = mExternalInits.at(initName);
+            dataPtr = (void*) initDesc.first;
+            nbytes = initDesc.second;
+        }
+        else if (onnxTensor.raw_data().size() > 0)
         {
             dataPtr = (void*) (onnxTensor.raw_data().data());
             nbytes = onnxTensor.raw_data().size();
@@ -416,6 +468,14 @@ bool WeightsContext::convertOnnxWeights(
         LOG_ERROR("Found unsupported datatype (" << onnxDtype << ") when importing initializer: " << onnxTensor.name());
         return false;
     }
+    // TRT expects empty weights to be nullptr.
+    if (nbytes == 0 && dataPtr != nullptr)
+    {
+        LOG_WARNING(
+            "Empty initializer " << initName << " was provided with non-empty data. Overriding data to nullptr");
+        dataPtr = nullptr;
+    }
+
     onnx2trt::ShapedWeights trt_weights(onnxDtype, dataPtr, shape);
     // Sanity check that weights were converted properly
     if (trt_weights.size_bytes() != nbytes)
@@ -448,9 +508,8 @@ float* WeightsContext::getFP32Values(ShapedWeights const& w)
 ShapedWeights WeightsContext::createNamedTempWeights(ShapedWeights::DataType type, nvinfer1::Dims const& shape,
     std::set<std::string>& namesSet, int64_t& suffixCounter, bool batchNormNode)
 {
-    std::string const& name
-        = generateUniqueName(namesSet, suffixCounter, batchNormNode ? "tmp_batch_norm_weight" : "tmp_weight");
-    return createNamedWeights(type, shape, name);
+    return createNamedWeights(type, shape,
+        generateUniqueName(namesSet, suffixCounter, batchNormNode ? "tmp_batch_norm_weight" : "tmp_weight"));
 }
 
 ShapedWeights WeightsContext::createTempWeights(ShapedWeights::DataType type, nvinfer1::Dims const& shape)
@@ -483,6 +542,46 @@ ShapedWeights WeightsContext::createNamedWeights(ShapedWeights::DataType type, n
         weights.setName(name.c_str());
     }
     return weights;
+}
+
+bool WeightsContext::loadExternalInit(char const* name, void const* data, size_t size)
+{
+    auto* ctx = this; // For logging macros.
+
+    if (!name)
+    {
+        LOG_ERROR("Cannot import an external initializer with a null name");
+        return false;
+    }
+
+    if (!data && size != 0)
+    {
+        LOG_ERROR("Cannot import a non-empty external initializer with null data");
+        return false;
+    }
+    // Validate name
+    auto it = mInitializers.find(name);
+    if (it == mInitializers.end())
+    {
+        LOG_ERROR("Cannot find initializer name: " << name << " in model!");
+        return false;
+    }
+    auto* init = it->second;
+
+    // Validate size
+    size_t byteSize = getTensorOrWeightsSizeBytes(getInitializerVol(init->dims()), init->data_type());
+    if (byteSize != size)
+    {
+        LOG_ERROR("Provided initializer size " << size << " mismatches with that expected by the model: " << byteSize);
+        return false;
+    }
+
+    if (mExternalInits.count(name))
+    {
+        LOG_WARNING("Initializer " << name << " was previously provided. Overwriting previous data.");
+    }
+    mExternalInits.insert_or_assign(name, std::make_pair(data, size));
+    return true;
 }
 
 } // namespace onnx2trt

--- a/WeightsContext.hpp
+++ b/WeightsContext.hpp
@@ -13,8 +13,13 @@
 
 namespace onnx2trt
 {
+#ifdef _WIN32
+typedef void* FileHandle;
+#else
+typedef int FileHandle;
+#endif
 
-// Class reponsible for reading, casting, and converting weight values from an ONNX model and into ShapedWeights
+// Class responsible for reading, casting, and converting weight values from an ONNX model and into ShapedWeights
 // objects. All temporary weights are stored in a buffer owned by the class so they do not go out of scope.
 
 class WeightsContext
@@ -31,15 +36,36 @@ class WeightsContext
 
     nvinfer1::ILogger* mLogger;
 
-    // Vector of hunks to maintain ownership of weights.
+    // Vector of chunks to maintain ownership of weights.
     std::vector<BufferPtr> mWeightBuffers;
 
     // Keeps track of the absolute location of the file in order to read external weights.
     std::string mOnnxFileLocation;
 
+    using MemoryMapping_t = std::pair<void*, int64_t>;
+    std::map<std::string, FileHandle> mMappedFiles;
+#ifdef _WIN32
+    std::map<std::string, FileHandle> mFileMappingHandles;
+#endif
+    std::map<std::string, MemoryMapping_t> mMemoryMappings;
+
+    template <typename T>
+    using StringMap = std::unordered_map<std::string, T>;
+
+    StringMap<::ONNX_NAMESPACE::TensorProto const*> mInitializers;
+
+    StringMap<std::pair<void const*, size_t>> mExternalInits;
+
 public:
     WeightsContext(nvinfer1::ILogger* logger)
         : mLogger(logger){};
+
+    ~WeightsContext();
+
+    WeightsContext(WeightsContext const& other) = delete;
+    WeightsContext& operator=(WeightsContext const& other) = delete;
+    WeightsContext(WeightsContext&& other) = delete;
+    WeightsContext& operator=(WeightsContext&& other) = delete;
 
     int32_t* convertUINT8(uint8_t const* weightValues, nvinfer1::Dims const& shape);
 
@@ -56,10 +82,7 @@ public:
         size_t const nBytes);
 
     // Function to read bytes from an external file and return the data in a buffer.
-    bool parseExternalWeights(
-
-        std::string const& file, int64_t offset, int64_t length, std::vector<char>& weightsBuf, size_t& size);
-
+    bool parseExternalWeights(std::string const& file, int64_t offset, int64_t length, MemoryMapping_t& weightsRef);
     // Function to read data from an ONNX Tensor and move it into a ShapedWeights object.
     // Handles external weights as well.
     bool convertOnnxWeights(
@@ -100,6 +123,17 @@ public:
     {
         return *mLogger;
     }
+
+    MemoryMapping_t mmap(std::string const& file);
+
+    void clearMemoryMappings();
+
+    StringMap<::ONNX_NAMESPACE::TensorProto const*>& initializerMap()
+    {
+        return mInitializers;
+    }
+
+    bool loadExternalInit(char const* name, void const* data, size_t size);
 };
 
 template <typename DataType>

--- a/WeightsContextMemoryMap.cpp
+++ b/WeightsContextMemoryMap.cpp
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "WeightsContext.hpp"
+#include <fstream>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace onnx2trt
+{
+int64_t getFileSize(std::string const& file)
+{
+    std::ifstream fileStream(file, std::ios::binary);
+    if (!fileStream)
+    {
+        return -1L;
+    }
+    fileStream.seekg(0, std::ios::end);
+    std::streamsize fileSize = fileStream.tellg();
+    return static_cast<int64_t>(fileSize);
+}
+
+#ifdef _WIN32
+WeightsContext::MemoryMapping_t WeightsContext::mmap(std::string const& file)
+{
+    auto* ctx = this; // For logging macros.
+
+    auto it = mMemoryMappings.find(file);
+    if (it != mMemoryMappings.end())
+    {
+        return it->second;
+    }
+
+    int64_t fileSize = getFileSize(file);
+
+    if (fileSize < 0L)
+    {
+        LOG_ERROR("Failed to open file: " << file);
+        return {nullptr, -1L};
+    }
+
+    FileHandle fd
+        = CreateFileA(file.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+    if (fd == INVALID_HANDLE_VALUE)
+    {
+        LOG_ERROR("Failed to open file: " << file);
+        return {nullptr, -1L};
+    }
+
+    FileHandle mappingHandle = CreateFileMapping(fd, nullptr, PAGE_READONLY, 0U, 0U, nullptr);
+
+    if (mappingHandle == INVALID_HANDLE_VALUE)
+    {
+        LOG_ERROR("Failed to map file to memory: " << file);
+        CloseHandle(fd);
+        return {nullptr, -1L};
+    }
+
+    auto const mappedAddr = MapViewOfFile(mappingHandle, FILE_MAP_READ, 0U, 0U, 0U);
+
+    if (mappedAddr == nullptr)
+    {
+        LOG_ERROR("Failed to map file to memory: " << file);
+        CloseHandle(fd);
+        CloseHandle(mappingHandle);
+        return {nullptr, -1L};
+    }
+
+    mMappedFiles[file] = fd;
+    mFileMappingHandles[file] = mappingHandle;
+    mMemoryMappings[file] = std::make_pair(mappedAddr, fileSize);
+    return std::make_pair(mappedAddr, fileSize);
+}
+
+void WeightsContext::clearMemoryMappings()
+{
+    for (auto const& [file, mapping] : mMemoryMappings)
+    {
+        UnmapViewOfFile(mapping.first);
+    }
+
+    for (auto const& [file, fd] : mFileMappingHandles)
+    {
+        CloseHandle(fd);
+    }
+
+    for (auto const& [file, fd] : mMappedFiles)
+    {
+        CloseHandle(fd);
+    }
+
+    mMappedFiles.clear();
+    mFileMappingHandles.clear();
+    mMemoryMappings.clear();
+}
+#else
+WeightsContext::MemoryMapping_t WeightsContext::mmap(std::string const& file)
+{
+    auto* ctx = this; // For logging macros.
+
+    auto it = mMemoryMappings.find(file);
+    if (it != mMemoryMappings.end())
+    {
+        return it->second;
+    }
+
+    int64_t fileSize = getFileSize(file);
+
+    if (fileSize < 0L)
+    {
+        LOG_ERROR("Failed to open file: " << file);
+        return {nullptr, -1L};
+    }
+
+    FileHandle fd = open(file.c_str(), O_RDONLY);
+
+    if (fd == -1L)
+    {
+        LOG_ERROR("Failed to open file: " << file);
+        return {nullptr, -1L};
+    }
+
+    void* mappedAddr = ::mmap(nullptr, fileSize, PROT_READ, MAP_PRIVATE, fd, 0);
+
+    if (mappedAddr == MAP_FAILED)
+    {
+        LOG_ERROR("Failed to map file to memory: " << file);
+        close(fd);
+        return {nullptr, -1L};
+    }
+
+    mMappedFiles[file] = fd;
+    mMemoryMappings[file] = std::make_pair(mappedAddr, fileSize);
+    return std::make_pair(mappedAddr, fileSize);
+}
+
+void WeightsContext::clearMemoryMappings()
+{
+    for (auto const& [file, mapping] : mMemoryMappings)
+    {
+        ::munmap(mapping.first, mapping.second);
+    }
+
+    for (auto const& [file, fd] : mMappedFiles)
+    {
+        close(fd);
+    }
+
+    mMappedFiles.clear();
+    mMemoryMappings.clear();
+}
+#endif
+} // namespace onnx2trt

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,15 @@
 
 # ONNX-TensorRT Changelog
 
+# TensorRT 10.13 GA Release - 2025-7-24
+For more details, see the 10.13 GA release notes
+
+- Decreased memory usage when importing models with external weights
+- Added `loadModelProto`, `loadInitializer` and `parseModelProto` APIs for IParser. These APIs are meant to be used to load user initializers when parsing ONNX models.
+- Added `loadModelProto`, `loadInitializer` and `refitModelProto` APIs for IParserRefitter. These APIs are meant to be used to load user initializers when refitting ONNX models.
+- Deprecated `IParser::parseWithWeightDescriptors`.
+- Unmarked `Protobuf` as a required dependency for building. If not found the ONNX submodule will install.
+
 # TensorRT 10.12 GA Release - 2025-6-16
 For more details, see the 10.12 GA release notes
 

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -2,7 +2,7 @@
 
 # Supported ONNX Operators
 
-TensorRT 10.12 supports operators in the inclusive range of opset 9 to opset 23. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
+TensorRT 10.13 supports operators in the inclusive range of opset 9 to opset 23. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
 
 TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, FP8, FP4, INT32, INT64, INT8, INT4, UINT8, and BOOL
 

--- a/importerUtils.cpp
+++ b/importerUtils.cpp
@@ -71,7 +71,7 @@ nvinfer1::ITensor* addClip(ImporterContext* ctx, nvinfer1::ITensor* input, float
         return N_CHECK(layer->getOutput(0));
     }
     return input;
-};
+}
 
 NodeOutputs argMinMaxHelper(ImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node, size_t const nodeIdx,
     std::vector<TensorOrWeights>& inputs, nvinfer1::TopKOperation op)
@@ -883,12 +883,18 @@ nvinfer1::IPluginCreatorInterface* importPluginCreator(ImporterContext* ctx, std
 {
     nvinfer1::IPluginCreatorInterface* creator = nullptr;
 
-#if ENABLE_STD_PLUGIN
-    auto& pluginRegistry = ctx->network()->getBuilder().getPluginRegistry();
-
     int32_t numCreators = 0;
-    auto creators = pluginRegistry.getAllCreatorsRecursive(&numCreators);
+    std::vector<nvinfer1::IPluginCreatorInterface*> creators;
 
+    int32_t numStdCreators = 0;
+    auto& stdPluginRegistry = ctx->network()->getBuilder().getPluginRegistry();
+    auto stdCreators = stdPluginRegistry.getAllCreatorsRecursive(&numStdCreators);
+    if (numStdCreators > 0)
+    {
+        creators.insert(creators.end(), stdCreators, stdCreators + numStdCreators);
+    }
+
+    numCreators = creators.size();
     // Helper function to check if a plugin creator matches the requested plugin parameters
     auto matchesPlugin = [&](char const* name, char const* version, char const* ns) -> bool {
         return std::string(name) == pluginName && std::string(version) == pluginVersion
@@ -932,9 +938,9 @@ nvinfer1::IPluginCreatorInterface* importPluginCreator(ImporterContext* ctx, std
                 v3QuickCreator->getPluginNamespace());
             break;
         }
-            // No default case as the creatorVersion is guaranteed to be one of the above as per
-            // `getPluginCreatorVersion()`. For any future plugin creator versions added, this switch statement will
-            // need to be updated along with `getPluginCreatorVersion()`.
+       // No default case as the creatorVersion is guaranteed to be one of the above as per
+       // `getPluginCreatorVersion()`. For any future plugin creator versions added, this switch statement will
+       // need to be updated along with `getPluginCreatorVersion()`.
         }
 
         if (matches)
@@ -943,11 +949,8 @@ nvinfer1::IPluginCreatorInterface* importPluginCreator(ImporterContext* ctx, std
             break;
         }
     }
-#endif // ENABLE_STD_PLUGIN
 
 
-    // Do not perform a N_CHECK here as a plugin not being found is a valid case. It is up to the callers to handle the
-    // nullptr correctly.
     return creator;
 }
 

--- a/onnxErrorRecorder.cpp
+++ b/onnxErrorRecorder.cpp
@@ -76,10 +76,9 @@ void ONNXParserErrorRecorder::clear() noexcept
     {
         logError(mLogger, e.what());
     }
-};
+}
 
-bool ONNXParserErrorRecorder::reportError(
-    nvinfer1::ErrorCode val, nvinfer1::IErrorRecorder::ErrorDesc desc) noexcept
+bool ONNXParserErrorRecorder::reportError(nvinfer1::ErrorCode val, nvinfer1::IErrorRecorder::ErrorDesc desc) noexcept
 {
     try
     {

--- a/onnxOpImporters.cpp
+++ b/onnxOpImporters.cpp
@@ -940,7 +940,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Conv)
 DEFINE_BUILTIN_OP_IMPORTER(ConvTranspose)
 {
     // Expand spatial dims from 1D to 2D, return true if reshaped activation
-    auto const NCWtoNCHW = [&ctx, &node](nvinfer1::ITensor*& tensor, nvinfer1::Dims& tensorShape) {
+    auto const NCWtoNCHW = [&ctx](nvinfer1::ITensor*& tensor, nvinfer1::Dims& tensorShape) {
         if (tensor && tensor->getDimensions().nbDims == 3)
         {
             std::vector<int32_t> const axes{3};
@@ -1940,7 +1940,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Dropout)
 
 DEFINE_BUILTIN_OP_IMPORTER(Einsum)
 {
-    checkNotInvalidType(inputs.at(0), {"UINT8"}, node, nodeIdx);
+    checkNotInvalidType(inputs.at(0), {"UINT8", "INT32", "INT64"}, node, nodeIdx);
     OnnxAttrs attrs(node, ctx);
     std::string equation = attrs.get<std::string>("equation");
 
@@ -2638,7 +2638,7 @@ DEFINE_BUILTIN_OP_IMPORTER(GRU)
     nvinfer1::ITensor* iterationInput = addRNNInput(ctx, node, loop, inputs, direction);
 
     // H(t-1)
-    auto const getInitialInputValue = [&ctx, &gateOutputShape, &inputs, &node](size_t inputIdx) -> nvinfer1::ITensor* {
+    auto const getInitialInputValue = [&ctx, &gateOutputShape, &inputs](size_t inputIdx) -> nvinfer1::ITensor* {
         if (inputs.size() > inputIdx && inputs.at(inputIdx))
         {
             return &convertToTensor(inputs.at(inputIdx), ctx);
@@ -3448,7 +3448,7 @@ DEFINE_BUILTIN_OP_IMPORTER(LSTM)
     nvinfer1::ITensor* gateOutputShape = initialStateShape();
     LOG_VERBOSE("Gate output rank (equal to initial hidden/cell state rank): " << gateOutputShape->getDimensions());
 
-    auto const getInitialInputValue = [&ctx, &gateOutputShape, &inputs, &node](size_t inputIdx) -> nvinfer1::ITensor* {
+    auto const getInitialInputValue = [&ctx, &gateOutputShape, &inputs](size_t inputIdx) -> nvinfer1::ITensor* {
         if (inputs.size() > inputIdx && inputs.at(inputIdx))
         {
             return &convertToTensor(inputs.at(inputIdx), ctx);
@@ -3528,7 +3528,7 @@ DEFINE_BUILTIN_OP_IMPORTER(LSTM)
         peephole = &convertToTensor(inputs.at(7), ctx);
     }
 
-    auto const addPeephole = [&ctx, &node, &hiddenSize, &numDirections, &peephole](nvinfer1::ITensor* gate,
+    auto const addPeephole = [&ctx, &hiddenSize, &numDirections, &peephole](nvinfer1::ITensor* gate,
                                  nvinfer1::ITensor* cellState, int32_t gateIndex) -> nvinfer1::ITensor* {
         nvinfer1::ISliceLayer* isolatePeephole
             = N_CHECK(ctx->network()->addSlice(*peephole, nvinfer1::Dims2{0, gateIndex * hiddenSize},
@@ -4153,7 +4153,7 @@ DEFINE_BUILTIN_OP_IMPORTER(NonMaxSuppression)
     indices = castHelper(ctx, indices, DataType::kINT64);
 
     return {{indices}};
-};
+}
 
 DEFINE_BUILTIN_OP_IMPORTER(Not)
 {
@@ -5158,8 +5158,7 @@ DEFINE_BUILTIN_OP_IMPORTER(RNN)
         return N_CHECK(concatenatedShape->getOutput(0));
     };
 
-    auto const getInitialInputValue
-        = [&ctx, &initialStateShape, &inputs, &node](size_t inputIdx) -> nvinfer1::ITensor* {
+    auto const getInitialInputValue = [&ctx, &initialStateShape, &inputs](size_t inputIdx) -> nvinfer1::ITensor* {
         if (inputs.size() > inputIdx && inputs.at(inputIdx))
         {
             return &convertToTensor(inputs.at(inputIdx), ctx);

--- a/onnxProtoUtils.hpp
+++ b/onnxProtoUtils.hpp
@@ -67,6 +67,9 @@ void deserializeOnnxModel(void const* serializedModel, size_t serializedModelSiz
     // Note: This WARs the very low default size limit (64MB)
     codedInput.SetTotalBytesLimit(std::numeric_limits<int>::max(), std::numeric_limits<int>::max() / 4);
 #endif
+
+    ONNXTRT_CHECK(model->ByteSizeLong() == 0, "A model was previously parsed!", ErrorCode::kMODEL_DESERIALIZE_FAILED);
+
     ONNXTRT_CHECK(model->ParseFromCodedStream(&codedInput), "Failed to parse the ONNX model.",
         ErrorCode::kMODEL_DESERIALIZE_FAILED);
 }

--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 
 from . import backend
 
-__version__ = "10.12.0"
+__version__ = "10.13.0"


### PR DESCRIPTION
# TensorRT 10.13 GA Release - 2025-7-24
For more details, see the 10.13 GA release notes

- Decreased memory usage when importing models with external weights
- Added `loadModelProto`, `loadInitializer` and `parseModelProto` APIs for IParser. These APIs are meant to be used to load user initializers when parsing ONNX models.
- Added `loadModelProto`, `loadInitializer` and `refitModelProto` APIs for IParserRefitter. These APIs are meant to be used to load user initializers when refitting ONNX models.
- Deprecated `IParser::parseWithWeightDescriptors`.
- Unmarked `Protobuf` as a required dependency for building. If not found the ONNX submodule will install.