### PR TITLE
"Build without cuda runtime library" approach 2

### DIFF
--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-
-from __future__ import absolute_import
-
+from importlib.metadata import version as _v, PackageNotFoundError  # Py3.8+
 from . import backend
 
-__version__ = "10.13.0"
+try:
+    __version__ = _v("onnx_tensorrt")
+except PackageNotFoundError:
+    __version__ = "0+unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "onnx_tensorrt"
+version = "10.13.0"
+description = "ONNX-TensorRT - TensorRT backend for running ONNX models"
+readme = { file = "README.md", content-type = "text/markdown" }
+license = { text = "Apache-2.0" }
+authors = [{ name = "NVIDIA", email = "svc_tensorrt@nvidia.com" }]
+classifiers = [
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3",
+]
+dependencies = ["pycuda", "numpy", "onnx"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["onnx_tensorrt*"]


### PR DESCRIPTION
Fixes: #643

Please see [PR #1035](https://github.com/onnx/onnx-tensorrt/pull/1035).

With this change, you no longer need to run:
```
python setup.py build
python -m pip install .
```

Instead, use the PEP 517 workflow:
```
python -m pip install -U build
python -m build --wheel
python -m pip install dist/*.whl
```