### PR TITLE
10.14-GA Release

### DIFF
--- a/AttentionHelpers.cpp
+++ b/AttentionHelpers.cpp
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include "AttentionHelpers.hpp"
+#include "ImporterContext.hpp"
+#include "NvInfer.h"
+#include "ShapeTensor.hpp"
+#include "errorHelpers.hpp"
+#include "importerUtils.hpp"
+#include <cmath>
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace
+{
+//!
+//! \brief Return true if `divident` is divisible by `divisor`.
+//!
+bool isDivisible(int64_t const divident, int64_t const divisor)
+{
+    return (divisor != 0) && ((divident % divisor) == 0);
+}
+} // namespace
+
+namespace onnx2trt
+{
+
+//!
+//! \brief Reshape and return the Q, K, or V tensor from the input tensor.
+//!
+//! \param qkvInput The input tensor. This can either be a 4D tensor (batchSize, numHeads, sequenceLength, headSize) or
+//!                 a 3D tensor (batchSize, sequenceLength, hiddenSize=numHeads*headSize). If it is a 3D tensor,
+//!                 permute and reshape to the 4D shape before returning. Otherwise, return the input tensor.
+//! \param attrs The ONNX node attributes.
+//! \param ctx The importer context.
+//! \param isQ True if the input tensor is the Q tensor, false if it is the K or V tensor.
+//! \return nvinfer1::ITensor& The Q, K, or V tensor.
+//!
+nvinfer1::ITensor& reshapeQKVTensor(
+    TensorOrWeights& qkvInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const isQ)
+{
+    if (qkvInput.shape().nbDims == 3)
+    {
+        // qkvInput is a 3D tensor (batchSize, sequenceLength, hiddenSize=numHeads * headSize).
+        // Get relevant dimensions.
+        int64_t const numHeadsValue
+            = isQ ? attrs.get<int64_t>("q_num_heads", 0) : attrs.get<int64_t>("kv_num_heads", 0);
+        ONNXTRT_CHECK(numHeadsValue != 0,
+            "q_num_heads and kv_num_heads attributes are not specified, which are required for 3D Q/K/V tensors",
+            ErrorCode::kINVALID_NODE);
+        ShapeTensor numHeads = shapeVector(numHeadsValue);
+
+        ShapeTensor hiddenSize = gather(ctx, shapeOf(qkvInput), shapeVector(2));
+        if (hiddenSize.allValuesKnown())
+        {
+            // Perform static check for divisibility.
+            ONNXTRT_CHECK(isDivisible(hiddenSize[0], numHeads[0]),
+                "hidden_size must be divisible by num_heads. Received hidden_size=" << hiddenSize[0]
+                                                                                    << " and num_heads=" << numHeads,
+                ErrorCode::kINVALID_NODE);
+        }
+
+        ShapeTensor headSize = floorDiv(ctx, hiddenSize, numHeads);
+
+        // == Transform (batchSize, sequenceLength, hiddenSize) -> (batchSize, numHeads, sequenceLength, headSize) by ==
+        // 1. Reshape to (batchSize, sequenceLength, numHeads, headSize).
+        // Use (0, 0, numHeads, headSize) as a shorthand to propagate `batchSize` and `sequenceLength` from the input
+        // tensor without instantiating them. Set `zeroIsPlaceholder` to enable this shorthand.
+        ShapeTensor newShape = concat(ctx, fillShapeVector(ctx, 0, shapeVector(2)), concat(ctx, numHeads, headSize));
+        nvinfer1::IShuffleLayer* shuffle
+            = addShuffle(ctx, convertToTensor(qkvInput, ctx), newShape, /*zeroIsPlaceholder*/ true);
+
+        // 2. Permute to (batchSize, numHeads, sequenceLength, headSize)
+        shuffle->setSecondTranspose({0, 2, 1, 3});
+
+        return *N_CHECK(shuffle->getOutput(0));
+    }
+    else
+    {
+        return convertToTensor(qkvInput, ctx);
+    }
+}
+
+//!
+//! \brief Scale the Q or K tensor by `sqrt(scale)`.
+//!
+//! `scale` is either provided as an attribute or set as the default value of `1/sqrt(headSize)`. `scale` is defined as
+//! `QK^T -> QK^T * scale`, but we apply `Q -> Q * sqrt(scale)` and `K -> K * sqrt(scale)` for numerical stability.
+//!
+//! \param qkTensor The Q or K tensor to scale.
+//! \param attrs The ONNX node attributes.
+//! \param ctx The importer context.
+//! \return nvinfer1::ITensor& The scaled Q or K tensor.
+//!
+nvinfer1::ITensor& scaleQKTensor(nvinfer1::ITensor& qkTensor, OnnxAttrs const& attrs, ImporterContext* ctx)
+{
+    nvinfer1::ITensor* sqrtScale = nullptr;
+
+    if (attrs.count("scale"))
+    {
+        // Obtain the sqrt of scale as a constant (output of a constant layer).
+        nvinfer1::IConstantLayer* constant = addConstantScalar(
+            ctx, std::sqrt(attrs.get<float>("scale")), ::ONNX_NAMESPACE::TensorProto::FLOAT, {4, {1, 1, 1, 1}});
+        sqrtScale = castHelper(ctx, N_CHECK(constant)->getOutput(0), qkTensor.getType());
+    }
+    else
+    {
+        ShapeTensor headSize = gather(ctx, shapeOf(qkTensor), shapeScalar(3));
+        nvinfer1::ITensor* headSizeF = castHelper(ctx, &headSize.tensor(ctx), qkTensor.getType());
+
+        // By default, scale := 1/sqrt(headSize)
+        nvinfer1::ITensor* sqrtHeadSize = getUnaryResult(ctx, *headSizeF, nvinfer1::UnaryOperation::kSQRT);
+        nvinfer1::ITensor* scale = getUnaryResult(ctx, *sqrtHeadSize, nvinfer1::UnaryOperation::kRECIP);
+
+        sqrtScale = getUnaryResult(ctx, *scale, nvinfer1::UnaryOperation::kSQRT);
+        sqrtScale = unsqueezeTensor(ctx, *sqrtScale, {0, 1, 2, 3});
+    }
+
+    // Scale Q or K tensor by `sqrt(scale)`.
+    return *getElementWiseResult(ctx, qkTensor, *sqrtScale, nvinfer1::ElementWiseOperation::kPROD);
+}
+
+nvinfer1::ITensor& convertToQTensor(TensorOrWeights& qInput, OnnxAttrs const& attrs, ImporterContext* ctx)
+{
+    return scaleQKTensor(reshapeQKVTensor(qInput, attrs, ctx, true), attrs, ctx);
+}
+
+nvinfer1::ITensor& convertToKTensor(TensorOrWeights& kInput, OnnxAttrs const& attrs, ImporterContext* ctx)
+{
+    return scaleQKTensor(reshapeQKVTensor(kInput, attrs, ctx, false), attrs, ctx);
+}
+
+nvinfer1::ITensor& convertToVTensor(TensorOrWeights& vInput, OnnxAttrs const& attrs, ImporterContext* ctx)
+{
+    return reshapeQKVTensor(vInput, attrs, ctx, false);
+}
+
+nvinfer1::ITensor& convertToMaskTensor(TensorOrWeights& maskInput, ImporterContext* ctx)
+{
+    ONNXTRT_CHECK(maskInput.shape().nbDims <= 4,
+        "Attention masks should have rank leq 4. Got mask with rank " << maskInput.shape().nbDims << ".",
+        ErrorCode::kINVALID_NODE);
+
+    if (maskInput.shape().nbDims == 4)
+    {
+        // Mask has rank 4. Directly return the mask tensor.
+        return convertToTensor(maskInput, ctx);
+    }
+    else
+    {
+        // Mask has rank less than 4. Reshape to rank 4 by prepending dimensions.
+        int32_t const numDimsToPrepend = 4 - maskInput.shape().nbDims;
+        std::vector<int32_t> unsqueezeAxes(numDimsToPrepend);
+        std::iota(unsqueezeAxes.begin(), unsqueezeAxes.end(), 0);
+
+        return *unsqueezeTensor(ctx, convertToTensor(maskInput, ctx), unsqueezeAxes);
+    }
+}
+
+nvinfer1::AttentionNormalizationOp parseNormalizationOp(OnnxAttrs const& attrs)
+{
+    std::string normalizationOp
+        = attrs.get<std::string>("TRT_normalization_op", "softmax"); // Normalization op defaults to softmax.
+    if (normalizationOp == "softmax")
+    {
+        return nvinfer1::AttentionNormalizationOp::kSOFTMAX;
+    }
+    else if (normalizationOp == "none")
+    {
+        return nvinfer1::AttentionNormalizationOp::kNONE;
+    }
+    else
+    {
+        ONNXTRT_CHECK(false, "Unsupported normalization op: " << normalizationOp, ErrorCode::kINVALID_NODE);
+    }
+}
+
+} // namespace onnx2trt

--- a/AttentionHelpers.hpp
+++ b/AttentionHelpers.hpp
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Helper functions used for importing the ONNX Attention operator.
+ *
+ */
+
+#pragma once
+
+#include "ImporterContext.hpp"
+#include "OnnxAttrs.hpp"
+
+namespace onnx2trt
+{
+
+//!
+//! \brief Convert the input tensor to the Q (query) tensor accepted by TensorRT.
+//!
+//! This is a wrapper over \p convertToTensor with the following additional transformations:
+//! 1) If the input is a 3D tensor with shape (batchSize, sequenceLength, hiddenSize=numHeads*headSize), permute and
+//!    reshape to the 4D tensor (batchSize, numHeads, sequenceLength, headSize) expected by TensorRT.
+//! 2) Obtain `scale` from the attribute if provided, otherwise use `1/sqrt(headSize)` as the default value. While
+//!    `scale` is defined on the QK^T product, apply `sqrt(scale)` on the Q tensor for numerical stability.
+//!
+//! \param qInput The input tensor to convert.
+//! \param attrs The attributes of the Attention node.
+//! \param ctx The importer context.
+//! \return nvinfer1::ITensor& The converted Q tensor with shape (batchSize, numHeads, sequenceLength, headSize).
+//!
+nvinfer1::ITensor& convertToQTensor(TensorOrWeights& qInput, OnnxAttrs const& attrs, ImporterContext* ctx);
+
+//!
+//! \brief Convert the input tensor to the K (key) tensor accepted by TensorRT.
+//!
+//! This is a wrapper over \p convertToTensor with the following additional transformations:
+//! 1) If the input is a 3D tensor with shape (batchSize, sequenceLength, hiddenSize=numHeads*headSize), permute and
+//!    reshape to the 4D tensor (batchSize, numHeads, sequenceLength, headSize) expected by TensorRT.
+//! 2) Obtain `scale` from the attribute if provided, otherwise use `1/sqrt(headSize)` as the default value. While
+//!    `scale` is defined on the QK^T product, apply `sqrt(scale)` on the K tensor for numerical stability.
+//!
+//! \param kInput The input tensor to convert.
+//! \param attrs The attributes of the Attention node.
+//! \param ctx The importer context.
+//! \return nvinfer1::ITensor& The converted K tensor with shape (batchSize, numHeads, sequenceLength, headSize).
+//!
+nvinfer1::ITensor& convertToKTensor(TensorOrWeights& kInput, OnnxAttrs const& attrs, ImporterContext* ctx);
+
+//!
+//! \brief Convert the input tensor to the V (value) tensor accepted by TensorRT.
+//!
+//! This is a wrapper over \p convertToTensor with the following additional transformation:
+//! 1) If the input is a 3D tensor with shape (batchSize, sequenceLength, hiddenSize=numHeads*headSize), permute and
+//!    reshape to the 4D tensor (batchSize, numHeads, sequenceLength, headSize) expected by TensorRT.
+//!
+//! \param vInput The input tensor to convert.
+//! \param attrs The attributes of the Attention node.
+//! \param ctx The importer context.
+//! \return nvinfer1::ITensor& The converted V tensor with shape (batchSize, numHeads, sequenceLength, headSize).
+//!
+nvinfer1::ITensor& convertToVTensor(TensorOrWeights& vInput, OnnxAttrs const& attrs, ImporterContext* ctx);
+
+//!
+//! \brief Convert the input tensor to the mask tensor accepted by TensorRT.
+//!
+//! \precondition: The input tensor shape is ONNX-broadcastable to (batchSize, qNumHeads, QSequenceLength,
+//! KVSequenceLength), where ONNX-broadcastable is defined as satisfying any one of the following:
+//! 1) The input tensor has exactly the same shape as the target shape.
+//! 2) The input tensor has the same rank (number of dimensions) as the target shape, and each dimension is either the
+//!    same as the target shape or 1.
+//! 3) The input tensor has less rank than the target shape, but it can have its shape
+//!    prepended with dimensions of length 1 to satisfy 2).
+//!
+//! \param maskInput The input tensor to convert.
+//! \param ctx The importer context.
+//! \return nvinfer1::ITensor& The converted mask tensor that is TensorRT-broadcastable to (batchSize, qNumHeads,
+//!         qSequenceLength, kvSequenceLength), where TensorRT-broadcastable is defined as satisfying properties 1) or
+//!         2) above, but not 3).
+//!
+nvinfer1::ITensor& convertToMaskTensor(TensorOrWeights& maskInput, ImporterContext* ctx);
+
+//!
+//! \brief Parse the normalization op from the attributes.
+//!
+//! While ONNX does not support specifying normalization op (always softmax), users could use the custom attribute
+//! \p TRT_normalization_op to set it for TensorRT.
+//!
+//! \param attrs The attributes of the Attention node.
+//! \return nvinfer1::AttentionNormalizationOp The parsed normalization op.
+//!
+nvinfer1::AttentionNormalizationOp parseNormalizationOp(OnnxAttrs const& attrs);
+
+} // namespace onnx2trt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 # Version information
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 10)
-set(ONNX2TRT_MINOR 13)
+set(ONNX2TRT_MINOR 14)
 set(ONNX2TRT_PATCH 0)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 
@@ -37,6 +37,7 @@ set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CAC
 #--------------------------------------------------
 
 set(IMPORTER_SOURCES
+    AttentionHelpers.cpp
     NvOnnxParser.cpp
     ModelImporter.cpp
     ModelRefitter.cpp
@@ -114,11 +115,11 @@ MESSAGE(STATUS "Found TensorRT headers at ${TENSORRT_INCLUDE_DIR}")
 # TensorRT Python Headers
 find_path(TENSORRT_PYTHON_INCLUDE_DIR NvInferPythonPlugin.h
   HINTS ${TENSORRT_ROOT}
-  PATH_SUFFIXES python/include/impl)
+  PATH_SUFFIXES include/impl)
 
 # If header is not found, download it from open source release.
 if(NOT TENSORRT_PYTHON_INCLUDE_DIR)
-  set(PLUGIN_URL "https://raw.githubusercontent.com/NVIDIA/TensorRT/refs/heads/release/${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}/python/include/impl/NvInferPythonPlugin.h")
+  set(PLUGIN_URL "https://raw.githubusercontent.com/NVIDIA/TensorRT/refs/heads/release/${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}/include/impl/NvInferPythonPlugin.h")
   set(FILE_DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/NvInferPythonPlugin.h")
 
   message(NOTICE "Required header NvInferPythonPlugin.h not found. Downloading from ${PLUGIN_URL} to ${FILE_DESTINATION}")

--- a/ImporterContext.cpp
+++ b/ImporterContext.cpp
@@ -26,6 +26,9 @@
         }                                                                                                              \
     } while (0)
 
+#define STRINGIFY(x) #x
+#define LITERAL(x) STRINGIFY(x)
+
 namespace
 {
 

--- a/ImporterContext.hpp
+++ b/ImporterContext.hpp
@@ -94,11 +94,13 @@ class ImporterContext
     std::set<std::string> mLayerNames;
     //! An increasing suffix counter used to uniquify layer names.
     int64_t mSuffixCounter{0};
-    //! Set to keep track of how many times a batch norm weight name shows up,
-    //! to avoid duplicate naming in TRT.
-    std::set<std::string> mBatchNormWeightNames;
-    //! An increasing suffix counter used to uniquify batch norm weight names.
-    int64_t mBatchNormWeightSuffixCounter{0};
+    //! Set to keep track of how many times a refittable name created by the parser shows up, to avoid duplicate naming in TRT.
+    //! Currently tracks the following nodes:
+    //!     1. BatchNorm - Parser pre-combines scales and bias weights for the IScaleLayer.
+    //!     2. ConstantOfShape - The value of the ConstantOfShape does not have a name, so the parser needs to create one for it.
+    std::set<std::string> mTempRefittableWeights;
+    //! An increasing suffix counter used to uniquify refittable weight names created by the parser.
+    int64_t mTempRefittableWeightsSuffixCounter{0};
     //! Set to hold output tensor names of layers that produce shape tensor outputs but do not
     //! natively support them.
     std::unordered_set<std::string> mUnsupportedShapeTensors;
@@ -221,12 +223,12 @@ public:
     }
 
     // Register an unique name for the created weights
-    ShapedWeights createNamedTempWeights(ShapedWeights::DataType type, nvinfer1::Dims shape, bool batchNormNode = false)
+    ShapedWeights createNamedTempWeights(ShapedWeights::DataType type, nvinfer1::Dims shape, bool refittable = false)
     {
-        if (batchNormNode)
+        if (refittable)
         {
             return mWeightsContext.createNamedTempWeights(
-                type, shape, mBatchNormWeightNames, mBatchNormWeightSuffixCounter, /*batchNormNode=*/true);
+                type, shape, mTempRefittableWeights, mTempRefittableWeightsSuffixCounter, /*refittable=*/true);
         }
         return mWeightsContext.createNamedTempWeights(type, shape, mTensorNames, mSuffixCounter);
     }

--- a/ModelImporter.cpp
+++ b/ModelImporter.cpp
@@ -509,7 +509,7 @@ void parseGraph(ImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const& graph,
     }
     catch (const std::exception& e)
     {
-        ONNXTRT_THROW(MAKE_ERROR("Failed to import initialzer", ErrorCode::kINVALID_GRAPH));
+        ONNXTRT_THROW(MAKE_ERROR(std::string("Failed to import initializer: ") + e.what(), ErrorCode::kINVALID_GRAPH));
     }
 
     // Keep track of graph outputs in the context to validate UINT8 nodes

--- a/ModelRefitter.cpp
+++ b/ModelRefitter.cpp
@@ -80,9 +80,9 @@ size_t ModelRefitter::batchnormWeightRefitter(
                                                                          : ::ONNX_NAMESPACE::TensorProto::FLOAT);
 
     ShapedWeights combinedScale = mWeightsContext.createNamedTempWeights(
-        weightType, scale.shape, mBatchNormWeightNames, mBatchNormWeightSuffixCounter, /*batchNormNode=*/true);
+        weightType, scale.shape, mTempRefittableWeights, mTempRefittableWeightsSuffixCounter, /*refittable=*/true);
     ShapedWeights combinedBias = mWeightsContext.createNamedTempWeights(
-        weightType, bias.shape, mBatchNormWeightNames, mBatchNormWeightSuffixCounter, /*batchNormNode=*/true);
+        weightType, bias.shape, mTempRefittableWeights, mTempRefittableWeightsSuffixCounter, /*refittable=*/true);
 
     // Validate that all the weights have the same amount of values
     bool allSame = scale.count() == bias.count() && mean.count() == scale.count() && variance.count() == scale.count()
@@ -189,6 +189,10 @@ void ModelRefitter::refitOnnxNode(::ONNX_NAMESPACE::NodeProto const& node, ::ONN
     {
         refitOnnxConstantNode(node, graph.name());
     }
+    else if (node.op_type() == "ConstantOfShape")
+    {
+        refitOnnxConstantOfShapeNode(node, graph.name());
+    }
     else if (node.op_type() == "BatchNormalization")
     {
         refitOnnxBatchNormNode(node, graph);
@@ -206,6 +210,46 @@ void ModelRefitter::refitOnnxNode(::ONNX_NAMESPACE::NodeProto const& node, ::ONN
         refitOnnxScanNode(node);
     }
     --nestedDepth;
+}
+
+void ModelRefitter::refitOnnxConstantOfShapeNode(::ONNX_NAMESPACE::NodeProto const& node, std::string const& graphName)
+{
+    ShapedWeights namedConstantOfShape = mWeightsContext.createNamedTempWeights(::ONNX_NAMESPACE::TensorProto::FLOAT, nvinfer1::Dims{1, {1}}, mTempRefittableWeights, mTempRefittableWeightsSuffixCounter, /*refittable=*/true);
+    std::string name = namedConstantOfShape.getName();
+
+    if (!mRefittableWeights.count(name))
+    {
+        return;
+    }
+    mRefittableWeights.erase(name);
+    if (mRefittedWeights.count(name))
+    {
+        LOG_REFITTER_WARNING("Duplicate weight name name ("
+            << name << ") was found when processing the graph (" << graphName
+            << "). The refit process would only work properly if both weights have the same values.");
+    }
+    else
+    {
+        mRefittedWeights.insert(name);
+    }
+
+    ShapedWeights weights;
+    if (node.attribute().size() == 1 && node.attribute(0).name() == "value")
+    {
+        ::ONNX_NAMESPACE::AttributeProto const& nodeAttribute = node.attribute(0);
+        ::ONNX_NAMESPACE::TensorProto const& onnx_weights_tensor = nodeAttribute.t();
+        ONNXTRT_CHECK(mWeightsContext.convertOnnxWeights(onnx_weights_tensor, &weights),
+            "Failed to import ConstantOfShape node.", ErrorCode::kUNSUPPORTED_NODE);
+    }
+    else
+    {
+        weights = namedConstantOfShape;
+        static_cast<float*>(weights.values)[0] = 0.f;
+    }
+
+    ONNXTRT_CHECK(mRefitter->setNamedWeights(name.c_str(), std::move(weights)), "Failed to set named weights",
+        ErrorCode::kREFIT_FAILED);
+    ++successfullyRefittedWeights;
 }
 
 void ModelRefitter::refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& node, std::string const& graphName)

--- a/ModelRefitter.hpp
+++ b/ModelRefitter.hpp
@@ -9,6 +9,7 @@
 #include "WeightsContext.hpp"
 #include "errorHelpers.hpp"
 #include <onnx/onnx_pb.h>
+#include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -44,10 +45,13 @@ private:
     //! Counter to limit the recursion depth to a set amount for nodes containing subgraphs.
     size_t nestedDepth{0};
 
-    //! Set to keep track of how many times a batch norm weight name shows up, to avoid duplicate naming in TRT.
-    std::set<std::string> mBatchNormWeightNames;
-    //! An increasing suffix counter used to uniquify batch norm weight names.
-    int64_t mBatchNormWeightSuffixCounter{0};
+    //! Set to keep track of how many times a refittable name created by the parser shows up, to avoid duplicate naming in TRT.
+    //! Currently tracks the following nodes:
+    //!     1. BatchNorm - Parser pre-combines scales and bias weights for the IScaleLayer.
+    //!     2. ConstantOfShape - The value of the ConstantOfShape does not have a name, so the parser needs to create one for it.
+    std::set<std::string> mTempRefittableWeights;
+    //! An increasing suffix counter used to uniquify refittable weight names created by the parser.
+    int64_t mTempRefittableWeightsSuffixCounter{0};
 
     size_t successfullyRefittedWeights{};
     std::unordered_set<std::string> mRefittableWeights;
@@ -68,6 +72,7 @@ private:
     void refitOnnxGraph(::ONNX_NAMESPACE::GraphProto const& graph);
     void refitOnnxNode(::ONNX_NAMESPACE::NodeProto const& node, ::ONNX_NAMESPACE::GraphProto const& graph);
     void refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& node, std::string const& graphName);
+    void refitOnnxConstantOfShapeNode(::ONNX_NAMESPACE::NodeProto const& node, std::string const& graphName);
     void refitOnnxBatchNormNode(::ONNX_NAMESPACE::NodeProto const& node, ::ONNX_NAMESPACE::GraphProto const& graph);
     void refitOnnxIfNode(::ONNX_NAMESPACE::NodeProto const& node);
     void refitOnnxLoopNode(::ONNX_NAMESPACE::NodeProto const& node);

--- a/OnnxAttrs.cpp
+++ b/OnnxAttrs.cpp
@@ -358,3 +358,4 @@ nvinfer1::ResizeRoundMode OnnxAttrs::get<nvinfer1::ResizeRoundMode>(std::string 
     }
     throw std::runtime_error("Unknown ResizeRoundMode: " + roundMode);
 }
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For press and other inquiries, please contact Hector Marinez at hmarinez@nvidia.
 
 ## Supported TensorRT Versions
 
-Development on the this branch is for the latest version of [TensorRT 10.13](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
+Development on the this branch is for the latest version of [TensorRT 10.14](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
 
 For previous versions of TensorRT, refer to their respective branches.
 
@@ -28,13 +28,13 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 
 ### Dependencies
 
- - [TensorRT 10.13](https://developer.nvidia.com/tensorrt)
- - [TensorRT 10.13 open source libraries](https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 10.14](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 10.14 open source libraries](https://github.com/NVIDIA/TensorRT/)
  - [Protobuf >= 3.20.3 (Optional)](https://github.com/google/protobuf/releases)
 
 ### Building
 
-For building within docker, we recommend using and setting up the docker containers as instructed in the main [TensorRT repository](https://github.com/NVIDIA/TensorRT#setting-up-the-build-environment) to build the onnx-tensorrt library.
+For building within Docker or on Windows, we recommend using the build instructions in the main [TensorRT repository](https://github.com/NVIDIA/TensorRT#setting-up-the-build-environment) to build the onnx-tensorrt library.
 
 Once you have cloned the repository, you can build the parser libraries and executables by running:
 
@@ -82,7 +82,7 @@ Refer to the link or run `polygraphy run -h` for more information on CLI options
 
 Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` files.
 
-TensorRT 10.13 supports ONNX release 1.18.0. Install it with:
+TensorRT 10.14 supports ONNX release 1.18.0. Install it with:
 
     python3 -m pip install onnx==1.18.0
 

--- a/TensorOrWeights.hpp
+++ b/TensorOrWeights.hpp
@@ -130,6 +130,11 @@ public:
         return is_tensor() ? tensor().getType() == nvinfer1::DataType::kUINT8
                            : weights().type == ::ONNX_NAMESPACE::TensorProto_DataType_UINT8;
     }
+    bool isInt4() const
+    {
+        return is_tensor() ? tensor().getType() == nvinfer1::DataType::kINT4
+                           : weights().type == ::ONNX_NAMESPACE::TensorProto_DataType_INT4;
+    }
     bool isBool() const
     {
         return is_tensor() ? tensor().getType() == nvinfer1::DataType::kBOOL
@@ -138,6 +143,17 @@ public:
     bool isFp8() const
     {
         return is_tensor() ? tensor().getType() == nvinfer1::DataType::kFP8 : weights().type == ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT8E4M3FN;
+    }
+    void setName(char const* name)
+    {
+        if (is_tensor())
+        {
+            tensor().setName(name);
+        }
+        else
+        {
+            weights().setName(name);
+        }
     }
     std::string getName() const
     {

--- a/WeightsContext.cpp
+++ b/WeightsContext.cpp
@@ -506,10 +506,10 @@ float* WeightsContext::getFP32Values(ShapedWeights const& w)
 }
 
 ShapedWeights WeightsContext::createNamedTempWeights(ShapedWeights::DataType type, nvinfer1::Dims const& shape,
-    std::set<std::string>& namesSet, int64_t& suffixCounter, bool batchNormNode)
+    std::set<std::string>& namesSet, int64_t& suffixCounter, bool refittable)
 {
     return createNamedWeights(type, shape,
-        generateUniqueName(namesSet, suffixCounter, batchNormNode ? "tmp_batch_norm_weight" : "tmp_weight"));
+        generateUniqueName(namesSet, suffixCounter, refittable ? "tmp_refittable_weight" : "tmp_weight"));
 }
 
 ShapedWeights WeightsContext::createTempWeights(ShapedWeights::DataType type, nvinfer1::Dims const& shape)

--- a/WeightsContext.hpp
+++ b/WeightsContext.hpp
@@ -95,9 +95,10 @@ public:
     // Helper function to get fp32 representation of fp16, bf16, or fp32 weights.
     float* getFP32Values(ShapedWeights const& w);
 
-    // Register an unique name for the created weights.
+    // Register an unique name for the created weights. If the weights are expected to be refittable by the IParserRefitter,
+    // use a different identifier.
     ShapedWeights createNamedTempWeights(ShapedWeights::DataType type, nvinfer1::Dims const& shape,
-        std::set<std::string>& namesSet, int64_t& suffixCounter, bool batchNormNode = false);
+        std::set<std::string>& namesSet, int64_t& suffixCounter, bool refittable = false);
 
     // Create weights with a given name.
     ShapedWeights createNamedWeights(ShapedWeights::DataType type, nvinfer1::Dims const& shape, std::string const& name,

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,13 @@
 
 # ONNX-TensorRT Changelog
 
+# TensorRT 10.14 GA Release - 2025-11-7
+For more details, see the 10.14 GA release notes
+
+- Added support for the `Attention` operator
+- Improved refit for `ConstantOfShape` nodes
+
+
 # TensorRT 10.13 GA Release - 2025-7-24
 For more details, see the 10.13 GA release notes
 

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -2,7 +2,7 @@
 
 # Supported ONNX Operators
 
-TensorRT 10.13 supports operators in the inclusive range of opset 9 to opset 23. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
+TensorRT 10.14 supports operators in the inclusive range of opset 9 to opset 24. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
 
 TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, FP8, FP4, INT32, INT64, INT8, INT4, UINT8, and BOOL
 
@@ -28,6 +28,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | Asinh                     | Y          | FP32, FP16, BF16 |
 | Atan                      | Y          | FP32, FP16, BF16 |
 | Atanh                     | Y          | FP32, FP16, BF16 |
+| Attention                 | Y          | FP32, FP16, BF16, INT8, FP8 | `Q`, `K`, `V` and `attn_mask ` must be 4D. `past_key`, `past_value` and `nonpad_kv_seqlen` inputs are unsupported. `present_key`, `present_value` and `qk_matmul_output` outputs are unsupported. `qk_matmul_output_mode` and `softcap` attributes are unsupported. `q_num_heads` and `kv_num_heads` attributes are supported via being specified as the second dimension of `Q` and `K`/`V`'s shapes respectively. |
 | AveragePool               | Y          | FP32, FP16, BF16 | 2D or 3D Pooling only. `dilations` must be empty or all ones                                                                                                              |
 | BatchNormalization        | Y          | FP32, FP16, BF16 |
 | Bernoulli                 | N          |

--- a/importerUtils.hpp
+++ b/importerUtils.hpp
@@ -12,7 +12,7 @@
 #include "errorHelpers.hpp"
 #include "weightUtils.hpp"
 
-#include "NvInferPythonPlugin.h"
+#include "impl/NvInferPythonPlugin.h"
 #include <NvInfer.h>
 
 #include "bfloat16.hpp"

--- a/onnxOpCheckers.cpp
+++ b/onnxOpCheckers.cpp
@@ -169,6 +169,20 @@ DEFINE_OP_EMPTY_CHECKER(Atan)
 
 DEFINE_OP_EMPTY_CHECKER(Atanh)
 
+DEFINE_OP_CHECKER(Attention)
+{
+    OnnxAttrs attrs(node, ctx);
+
+    // Check for unsupported attributes.
+    float const softcap = attrs.get<float>("softcap", 0.0);
+    STATIC_CHECK(softcap == 0.0 && "Setting softcap is not supported in TensorRT Attention.",
+        ErrorCode::kUNSUPPORTED_NODE, node, errors, nodeIndex);
+
+    bool const hasSoftmaxPrecision = static_cast<bool>(attrs.count("softmax_precision"));
+    STATIC_CHECK(!hasSoftmaxPrecision && "Setting softmax precision is not supported in TensorRT Attention.",
+        ErrorCode::kUNSUPPORTED_NODE, node, errors, nodeIndex);
+}
+
 DEFINE_OP_EMPTY_CHECKER(Add)
 
 DEFINE_OP_CHECKER(ArgMax)
@@ -260,6 +274,7 @@ DEFINE_OP_EMPTY_CHECKER(DepthToSpace)
 DEFINE_OP_EMPTY_CHECKER(QuantizeLinear)
 
 DEFINE_OP_EMPTY_CHECKER(DequantizeLinear)
+
 
 DEFINE_OP_EMPTY_CHECKER(TRT_FP8QuantizeLinear)
 

--- a/onnxOpImporters.cpp
+++ b/onnxOpImporters.cpp
@@ -7,6 +7,7 @@
 #endif
 #include <cmath>
 
+#include "AttentionHelpers.hpp"
 #include "ConditionalHelpers.hpp"
 #include "LoopHelpers.hpp"
 #include "ModelImporter.hpp"
@@ -31,6 +32,7 @@
 #include <sstream>
 #include <tuple>
 #include <unordered_set>
+
 
 namespace onnx2trt
 {
@@ -180,6 +182,43 @@ DEFINE_BUILTIN_OP_IMPORTER(Atanh)
     return unaryHelper(ctx, node, nodeIdx, inputs.at(0), nvinfer1::UnaryOperation::kATANH);
 }
 
+DEFINE_BUILTIN_OP_IMPORTER(Attention)
+{
+    ONNXTRT_CHECK_NODE(node.output().size() == 1, "TensorRT only supports Attention nodes with one output.", node,
+        nodeIdx, ErrorCode::kINVALID_NODE);
+
+    OnnxAttrs attrs(node, ctx);
+
+    // Get inputs.
+    nvinfer1::ITensor& query = convertToQTensor(inputs.at(0), attrs, ctx);
+    nvinfer1::ITensor& key = convertToKTensor(inputs.at(1), attrs, ctx);
+    nvinfer1::ITensor& value = convertToVTensor(inputs.at(2), attrs, ctx);
+    bool const hasAttnMask = inputs.size() > 3 && !inputs.at(3).isNullTensor();
+    bool const hasPastKey = inputs.size() > 4 && !inputs.at(4).isNullTensor();
+    bool const hasPastValue = inputs.size() > 5 && !inputs.at(5).isNullTensor();
+
+    ONNXTRT_CHECK_NODE(!hasPastKey, "Setting past_key for the Attention node is not supported in TensorRT.", node,
+        nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+    ONNXTRT_CHECK_NODE(!hasPastValue, "Setting past_value for the Attention node is not supported in TensorRT.", node,
+        nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+
+    // Get attributes.
+    bool const isCausal = static_cast<bool>(attrs.get<int64_t>("is_causal", 0));
+    nvinfer1::AttentionNormalizationOp const normOp = parseNormalizationOp(attrs);
+    bool const decomposable = static_cast<bool>(attrs.get<int64_t>("TRT_decomposable", 0));
+
+    // Add the Attention layer.
+    nvinfer1::IAttention* attention = N_CHECK(ctx->network()->addAttention(query, key, value, normOp, isCausal));
+    attention->setDecomposable(decomposable);
+
+    if (hasAttnMask)
+    {
+        attention->setMask(convertToMaskTensor(inputs.at(3), ctx));
+    }
+
+    return {{attention->getOutput(0)}};
+}
+
 DEFINE_BUILTIN_OP_IMPORTER(Add)
 {
     return elementwiseHelper(ctx, node, nodeIdx, inputs, nvinfer1::ElementWiseOperation::kSUM);
@@ -316,8 +355,8 @@ NodeOutputs batchnormWeightHelper(
         ? ::ONNX_NAMESPACE::TensorProto::BFLOAT16
         : (typeid(T).hash_code() == typeid(half_float::half).hash_code() ? ::ONNX_NAMESPACE::TensorProto::FLOAT16
                                                                          : ::ONNX_NAMESPACE::TensorProto::FLOAT);
-    auto combinedScale = ctx->createNamedTempWeights(weightType, scale.shape, /*batchNormNode=*/true);
-    auto combinedBias = ctx->createNamedTempWeights(weightType, bias.shape, /*batchNormNode=*/true);
+    auto combinedScale = ctx->createNamedTempWeights(weightType, scale.shape, /*refittable=*/true);
+    auto combinedBias = ctx->createNamedTempWeights(weightType, bias.shape, /*refittable=*/true);
 
     // Validate that all the weights have the same amount of values
     bool allSame = scale.count() == bias.count() && mean.count() == scale.count() && variance.count() == scale.count()
@@ -798,10 +837,12 @@ DEFINE_BUILTIN_OP_IMPORTER(ConstantOfShape)
     OnnxAttrs attrs(node, ctx);
     nvinfer1::ITensor* shape = &convertToTensor(inputs.at(0), ctx);
 
+    // For refit, create named temp weights for ConstantOfShape value tensors since they're not named by default.
     ShapedWeights zeroWeights
-        = ctx->createNamedTempWeights(::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, nvinfer1::Dims{1, {1}});
+        = ctx->createNamedTempWeights(::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, nvinfer1::Dims{1, {1}},  /*refittable=*/ true);
     static_cast<float*>(zeroWeights.values)[0] = 0.f;
-    auto valueWeights = TensorOrWeights{attrs.get("value", zeroWeights)};
+    auto valueWeights = TensorOrWeights{attrs.get<ShapedWeights>("value", zeroWeights)};
+    valueWeights.setName(zeroWeights.getName());
     nvinfer1::ITensor* value = &convertToTensor(valueWeights, ctx);
     return {{constantOfShape(ctx, value, shape)}};
 }
@@ -1319,6 +1360,7 @@ DEFINE_BUILTIN_OP_IMPORTER(DepthToSpace)
     return {{tensorPtr}};
 }
 
+
 // Backward traverse the graph to retrieve the input weights from the constant node. We allow skipping all cast/identity
 // nodes until reaching the constant node.
 ShapedWeights getWeightsFromIdentityOrConstant(nvinfer1::INetworkDefinition& network, nvinfer1::ITensor* input)
@@ -1434,8 +1476,12 @@ NodeOutputs QuantDequantLinearHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::Nod
             scaleAllPositive = true;
             isE8M0 = true;
         }
+
+        bool allowNegativeScale = false;
+
         ONNXTRT_CHECK_NODE(
-            scaleAllPositive, "Scale coefficients must all be positive", node, nodeIdx, ErrorCode::kINVALID_NODE);
+            (scaleAllPositive || allowNegativeScale), "Scale coefficients must all be positive", node, nodeIdx,
+            ErrorCode::kINVALID_NODE);
 
         // If the scale is concrete weights, then add a ConstantLayer that will be an input which
         // will initialize the scale weights.
@@ -3453,6 +3499,23 @@ DEFINE_BUILTIN_OP_IMPORTER(LSTM)
         {
             return &convertToTensor(inputs.at(inputIdx), ctx);
         }
+        auto tensorType = inputs.at(0).getType();
+        if (tensorType == "HALF")
+        {
+            return constantOfShape(ctx,
+                addConstantScalar(
+                    ctx, half_float::half(0.f), ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, nvinfer1::Dims{1, {1}})
+                    ->getOutput(0),
+                gateOutputShape);
+        }
+        if (tensorType == "BF16")
+        {
+            return constantOfShape(ctx,
+                addConstantScalar(
+                    ctx, BFloat16(0.f), ::ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16, nvinfer1::Dims{1, {1}})
+                    ->getOutput(0),
+                gateOutputShape);
+        }
         return constantOfShape(ctx,
             addConstantScalar(ctx, 0.f, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, nvinfer1::Dims{1, {1}})
                 ->getOutput(0),
@@ -4123,8 +4186,8 @@ DEFINE_BUILTIN_OP_IMPORTER(NonMaxSuppression)
         ErrorCode::kUNSUPPORTED_NODE);
 
     // Create the NMS layer
-    auto* layer = N_CHECK(
-        ctx->network()->addNMS(*boxesTensorPtr, *transposedScoresTensorPtr, *maxOutputBoxesPerClassTensorPtr));
+    auto* layer = N_CHECK(ctx->network()->addNMS(
+        *boxesTensorPtr, *transposedScoresTensorPtr, *maxOutputBoxesPerClassTensorPtr, DataType::kINT64));
     ctx->registerLayer(layer, node);
 
     // Handle the optional threshold inputs
@@ -4150,7 +4213,6 @@ DEFINE_BUILTIN_OP_IMPORTER(NonMaxSuppression)
     }
     layer->setBoundingBoxFormat(fmt);
     auto* indices = N_CHECK(layer->getOutput(0));
-    indices = castHelper(ctx, indices, DataType::kINT64);
 
     return {{indices}};
 }
@@ -6289,7 +6351,7 @@ DEFINE_BUILTIN_OP_IMPORTER(TopK)
             indices, "Failed to squeeze the input indices.", node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
     }
 
-    // TensorRT doesn't support int64 for TopK indices
+    // TensorRT will fuse TopK and Cast if dimension exceeds INT32_MAX
     indices = castHelper(ctx, indices, DataType::kINT64);
     return {{values, indices}};
 }
@@ -6916,9 +6978,9 @@ DEFINE_BUILTIN_OP_IMPORTER(NonZero)
         "this version of TensorRT. The current type is "
             + getTrtDtypeName(t) + ".",
         node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
-    auto* layer = N_CHECK(ctx->network()->addNonZero(*x));
+    auto* layer = N_CHECK(ctx->network()->addNonZero(*x, DataType::kINT64));
     ctx->registerLayer(layer, node);
-    return {{castHelper(ctx, N_CHECK(layer->getOutput(0)), DataType::kINT64)}};
+    return {{N_CHECK(layer->getOutput(0))}};
 }
 
 DEFINE_BUILTIN_OP_IMPORTER(Mish)

--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 
 from . import backend
 
-__version__ = "10.13.0"
+__version__ = "10.14.0"

--- a/onnx_tensorrt/tensorrt_engine.py
+++ b/onnx_tensorrt/tensorrt_engine.py
@@ -1,11 +1,182 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import tensorrt as trt
-import pycuda.driver
-import pycuda.gpuarray
-import pycuda.autoinit
 import numpy as np
 from six import string_types
+from cuda.bindings import runtime as cudart
+from typing import Union, Optional
+
+# RAII memory management classes
+import ctypes
+from cuda.bindings import driver as cuda, nvrtc
+
+
+class ArrayWithOwner(np.ndarray):
+    """Numpy array that holds a reference to its owner object"""
+    def __new__(cls, input_array, owner):
+        obj = np.asarray(input_array).view(cls)
+        obj._owner = owner
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self._owner = getattr(obj, '_owner', None)
+
+
+
+def cuda_call(call):
+    """Helper function to make CUDA calls and check for errors"""
+    def _cudaGetErrorEnum(error):
+        if isinstance(error, cuda.CUresult):
+            err, name = cuda.cuGetErrorName(error)
+            return name if err == cuda.CUresult.CUDA_SUCCESS else "<unknown>"
+        elif isinstance(error, cudart.cudaError_t):
+            return cudart.cudaGetErrorName(error)[1]
+        elif isinstance(error, nvrtc.nvrtcResult):
+            return nvrtc.nvrtcGetErrorString(error)[1]
+        else:
+            raise RuntimeError("Unknown error type: {}".format(error))
+
+    err, res = call[0], call[1:]
+    if err.value:
+        raise RuntimeError(
+            "CUDA error code={}({})".format(
+                err.value, _cudaGetErrorEnum(err)
+            )
+        )
+    if len(res) == 1:
+        return res[0]
+    elif len(res) == 0:
+        return None
+    else:
+        return res
+
+
+# Initialize CUDA
+cuda_call(cudart.cudaFree(0))
+
+
+class PinnedHostMem:
+    """Pinned host memory allocation for faster GPU transfers"""
+    def __init__(self, size: int, dtype: Optional[np.dtype] = None):
+        if dtype is None:
+            dtype = np.dtype(np.uint8)
+        else:
+            dtype = np.dtype(dtype)
+        nbytes = size * dtype.itemsize
+        host_mem = cuda_call(cudart.cudaMallocHost(nbytes))
+
+        self._host_ptr = host_mem
+        self._host_size = size
+        self._nbytes = nbytes
+        self._dtype = dtype
+
+    @property
+    def array(self) -> np.ndarray:
+        # Create view with proper memory ownership
+        pointer_type = ctypes.POINTER(np.ctypeslib.as_ctypes_type(self._dtype))
+        host_array = np.ctypeslib.as_array(ctypes.cast(self._host_ptr, pointer_type), (self._host_size,))
+        return ArrayWithOwner(host_array, self)
+
+    @array.setter
+    def array(self, data: Union[np.ndarray, bytes]):
+        """Set the array data with proper bounds checking"""
+        host_array = self.array  # Get the numpy array view
+        if isinstance(data, np.ndarray):
+            if data.size > self._host_size:
+                raise ValueError(
+                    f"Tried to fit an array of size {data.size} into host memory of size {self._host_size}"
+                )
+            np.copyto(host_array[:data.size], data.flat, casting='safe')
+        else:
+            assert self._dtype == np.uint8
+            host_array[:self.nbytes] = np.frombuffer(data, dtype=np.uint8)
+
+    @property
+    def nbytes(self) -> int:
+        return self._nbytes
+
+    def free(self):
+        """Explicitly free pinned host memory"""
+        if self._host_ptr is not None:
+            try:
+                cuda_call(cudart.cudaFreeHost(self._host_ptr))
+                self._host_ptr = None
+            except Exception:
+                # Log but don't raise - cleanup should be best effort
+                pass
+
+    def __str__(self):
+        return f"PinnedHost:\n{self.array}\nSize:\n{self.nbytes}\n"
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __del__(self):
+        # Fallback cleanup - not guaranteed to be called
+        self.free()
+
+
+class DeviceMem:
+    """Device-only memory allocation for cases where host memory is not needed"""
+    def __init__(self, size: int):
+        self._device_ptr = cuda_call(cudart.cudaMalloc(size))
+        self._nbytes = size
+
+    @property
+    def device_ptr(self) -> int:
+        """Device memory pointer"""
+        return self._device_ptr
+
+    @property
+    def nbytes(self) -> int:
+        return self._nbytes
+
+    def free(self):
+        """Explicitly free device memory"""
+        if self._device_ptr is not None:
+            try:
+                cuda_call(cudart.cudaFree(self._device_ptr))
+                self._device_ptr = None
+            except Exception:
+                # Log but don't raise - cleanup should be best effort
+                pass
+
+    def __str__(self):
+        return f"Device:\n{self.device_ptr}\nSize:\n{self.nbytes}\n"
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __del__(self):
+        # Fallback cleanup - not guaranteed to be called
+        self.free()
+
+
+class CudaStream:
+    """RAII wrapper for CUDA stream"""
+    def __init__(self):
+        self._stream = cuda_call(cudart.cudaStreamCreate())
+
+    @property
+    def stream(self):
+        return self._stream
+
+    def free(self):
+        """Explicitly free the CUDA stream"""
+        if self._stream is not None:
+            try:
+                cuda_call(cudart.cudaStreamDestroy(self._stream))
+                self._stream = None
+            except Exception:
+                # Log but don't raise - cleanup should be best effort
+                pass
+
+    def __del__(self):
+        # Fallback cleanup - not guaranteed to be called
+        self.free()
+
 
 class Binding(object):
     def __init__(self, engine, idx_or_name):
@@ -33,23 +204,26 @@ class Binding(object):
         shape = engine.get_tensor_shape(self.name)
 
         self.shape = tuple(shape)
-        self._host_buf   = None
-        self._device_buf = None
+        self._host_buf = None
+        self._device_mem = None
+
     @property
     def host_buffer(self):
         if self._host_buf is None:
-            self._host_buf = pycuda.driver.pagelocked_empty(self.shape, self.dtype)
-        return self._host_buf
+            size = np.prod(self.shape)
+            self._host_buf = PinnedHostMem(size, np.dtype(self.dtype))
+        return self._host_buf.array
+
     @property
     def device_buffer(self):
-        if self._device_buf is None:
-            self._device_buf = pycuda.gpuarray.empty(self.shape, self.dtype)
-        return self._device_buf
+        if self._device_mem is None:
+            size = np.prod(self.shape)
+            nbytes = size * np.dtype(self.dtype).itemsize
+            self._device_mem = DeviceMem(nbytes)
+        return self._device_mem.device_ptr
     def get_async(self, stream):
-        src = self.device_buffer
-        dst = self.host_buffer
-        src.get_async(stream, dst)
-        return dst
+        cuda_call(cudart.cudaMemcpyAsync(self.host_buffer.ctypes.data, self.device_buffer, self.host_buffer.nbytes, cudart.cudaMemcpyKind.cudaMemcpyDeviceToHost, stream))
+        return self.host_buffer
 
 def squeeze_hw(x):
     if x.shape[-2:] == (1, 1):
@@ -90,19 +264,16 @@ class Engine(object):
 
         bindings = [Binding(self.engine, i)
                     for i in range(self.engine.num_io_tensors)]
-        self.binding_addrs = [b.device_buffer.ptr for b in bindings]
+        self.binding_addrs = [int(b.device_buffer) for b in bindings]
         self.inputs  = [b for b in bindings if     b.is_input]
         self.outputs = [b for b in bindings if not b.is_input]
-        
+
         for binding in self.inputs + self.outputs:
             _ = binding.device_buffer # Force buffer allocation
         for binding in self.outputs:
             _ = binding.host_buffer   # Force buffer allocation
         self.context = self.engine.create_execution_context()
-        self.stream = pycuda.driver.Stream()
-    def __del__(self):
-        if self.engine is not None:
-            del self.engine
+        self.stream = CudaStream()
 
     def run(self, inputs):
         # len(inputs) > len(self.inputs) with Shape operator, input is never used
@@ -116,8 +287,7 @@ class Engine(object):
 
         for i, (input_array, input_binding) in enumerate(zip(inputs, self.inputs)):
             input_array = check_input_validity(i, input_array, input_binding)
-            input_binding_array = input_binding.device_buffer
-            input_binding_array.set_async(input_array, self.stream)
+            cuda_call(cudart.cudaMemcpyAsync(input_binding.device_buffer, input_array.ctypes.data, input_array.nbytes, cudart.cudaMemcpyKind.cudaMemcpyHostToDevice, self.stream.stream))
 
         num_io = self.engine.num_io_tensors
         for i in range(num_io):
@@ -127,12 +297,13 @@ class Engine(object):
             else:
                 self.context.set_tensor_address(tensor_name, self.binding_addrs[i])
 
-        self.context.execute_async_v3(self.stream.handle)
+        self.context.execute_async_v3(self.stream.stream)
 
-        results = [output.get_async(self.stream)
+        results = [output.get_async(self.stream.stream)
                    for output in self.outputs]
-        self.stream.synchronize()
+        cuda_call(cudart.cudaStreamSynchronize(self.stream.stream))
+
         return results
 
     def run_no_dma(self):
-        self.context.execute_async_v3(self.stream.handle)
+        self.context.execute_async_v3(self.stream.stream)


### PR DESCRIPTION
# TensorRT 10.14 GA Release - 2025-11-6
For more details, see the [10.14 GA release notes](https://docs.nvidia.com/deeplearning/tensorrt/latest/getting-started/release-notes.html#tensorrt-10-14-1)

- Added support for the `Attention` operator
- Improved refit for `ConstantOfShape` nodes