### PR TITLE
10.15-GA Release

### DIFF
--- a/AttentionHelpers.cpp
+++ b/AttentionHelpers.cpp
@@ -40,9 +40,9 @@ namespace onnx2trt
 //! \return nvinfer1::ITensor& The Q, K, or V tensor.
 //!
 nvinfer1::ITensor& reshapeQKVTensor(
-    TensorOrWeights& qkvInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const isQ)
+    TensorOrWeights& qkvInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const isQ, bool const needsReshape)
 {
-    if (qkvInput.shape().nbDims == 3)
+    if (needsReshape)
     {
         // qkvInput is a 3D tensor (batchSize, sequenceLength, hiddenSize=numHeads * headSize).
         // Get relevant dimensions.
@@ -102,8 +102,8 @@ nvinfer1::ITensor& scaleQKTensor(nvinfer1::ITensor& qkTensor, OnnxAttrs const& a
     if (attrs.count("scale"))
     {
         // Obtain the sqrt of scale as a constant (output of a constant layer).
-        nvinfer1::IConstantLayer* constant = addConstantScalar(
-            ctx, std::sqrt(attrs.get<float>("scale")), ::ONNX_NAMESPACE::TensorProto::FLOAT, {4, {1, 1, 1, 1}});
+        nvinfer1::IConstantLayer* constant
+            = addConstantScalar(ctx, std::sqrt(attrs.get<float>("scale")), ::ONNX_NAMESPACE::TensorProto::FLOAT, 4);
         sqrtScale = castHelper(ctx, N_CHECK(constant)->getOutput(0), qkTensor.getType());
     }
     else
@@ -123,19 +123,22 @@ nvinfer1::ITensor& scaleQKTensor(nvinfer1::ITensor& qkTensor, OnnxAttrs const& a
     return *getElementWiseResult(ctx, qkTensor, *sqrtScale, nvinfer1::ElementWiseOperation::kPROD);
 }
 
-nvinfer1::ITensor& convertToQTensor(TensorOrWeights& qInput, OnnxAttrs const& attrs, ImporterContext* ctx)
+nvinfer1::ITensor& convertToQTensor(
+    TensorOrWeights& qInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape)
 {
-    return scaleQKTensor(reshapeQKVTensor(qInput, attrs, ctx, true), attrs, ctx);
+    return scaleQKTensor(reshapeQKVTensor(qInput, attrs, ctx, true /*isQ*/, needsReshape), attrs, ctx);
 }
 
-nvinfer1::ITensor& convertToKTensor(TensorOrWeights& kInput, OnnxAttrs const& attrs, ImporterContext* ctx)
+nvinfer1::ITensor& convertToKTensor(
+    TensorOrWeights& kInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape)
 {
-    return scaleQKTensor(reshapeQKVTensor(kInput, attrs, ctx, false), attrs, ctx);
+    return scaleQKTensor(reshapeQKVTensor(kInput, attrs, ctx, false /*isQ*/, needsReshape), attrs, ctx);
 }
 
-nvinfer1::ITensor& convertToVTensor(TensorOrWeights& vInput, OnnxAttrs const& attrs, ImporterContext* ctx)
+nvinfer1::ITensor& convertToVTensor(
+    TensorOrWeights& vInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape)
 {
-    return reshapeQKVTensor(vInput, attrs, ctx, false);
+    return reshapeQKVTensor(vInput, attrs, ctx, false /*isQ*/, needsReshape);
 }
 
 nvinfer1::ITensor& convertToMaskTensor(TensorOrWeights& maskInput, ImporterContext* ctx)
@@ -178,4 +181,29 @@ nvinfer1::AttentionNormalizationOp parseNormalizationOp(OnnxAttrs const& attrs)
     }
 }
 
+nvinfer1::ITensor& reshapeOutputTensor(nvinfer1::ITensor& tensor, ImporterContext* ctx, bool const needsReshape)
+{
+    if (!needsReshape)
+    {
+        return tensor;
+    }
+    else
+    {
+        ShapeTensor numHeads = gather(ctx, shapeOf(tensor), shapeVector(1));
+        ShapeTensor headSize = gather(ctx, shapeOf(tensor), shapeVector(3));
+        ShapeTensor hiddenSize = mul(ctx, numHeads, headSize);
+
+        // == Transform (batchSize, numHeads, sequenceLength, headSize) -> (batchSize, sequenceLength, hiddenSize) by ==
+        // 1. Transpose the middle two dimensions: (batchSize, numHeads, sequenceLength, headSize) -> (batchSize,
+        // sequenceLength, numHeads, headSize)
+        // 2. Reshape to (batchSize, sequenceLength, hiddenSize).
+        // Use (0, 0, hiddenSize) as a shorthand to propagate `batchSize` and `sequenceLength` from the input
+        // tensor without instantiating them. Set `zeroIsPlaceholder` to enable this shorthand.
+        ShapeTensor newShape = concat(ctx, fillShapeVector(ctx, 0, shapeVector(2)), hiddenSize);
+        nvinfer1::IShuffleLayer* shuffle = addShuffle(ctx, tensor, newShape, /*zeroIsPlaceholder*/ true);
+        shuffle->setFirstTranspose({0, 2, 1, 3});
+
+        return *N_CHECK(shuffle->getOutput(0));
+    }
+}
 } // namespace onnx2trt

--- a/AttentionHelpers.hpp
+++ b/AttentionHelpers.hpp
@@ -25,9 +25,11 @@ namespace onnx2trt
 //! \param qInput The input tensor to convert.
 //! \param attrs The attributes of the Attention node.
 //! \param ctx The importer context.
+//! \param needsReshape True if the input tensor needs to be reshaped to 4D, false otherwise.
 //! \return nvinfer1::ITensor& The converted Q tensor with shape (batchSize, numHeads, sequenceLength, headSize).
 //!
-nvinfer1::ITensor& convertToQTensor(TensorOrWeights& qInput, OnnxAttrs const& attrs, ImporterContext* ctx);
+nvinfer1::ITensor& convertToQTensor(
+    TensorOrWeights& qInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape = false);
 
 //!
 //! \brief Convert the input tensor to the K (key) tensor accepted by TensorRT.
@@ -41,9 +43,11 @@ nvinfer1::ITensor& convertToQTensor(TensorOrWeights& qInput, OnnxAttrs const& at
 //! \param kInput The input tensor to convert.
 //! \param attrs The attributes of the Attention node.
 //! \param ctx The importer context.
+//! \param needsReshape True if the input tensor needs to be reshaped to 4D, false otherwise.
 //! \return nvinfer1::ITensor& The converted K tensor with shape (batchSize, numHeads, sequenceLength, headSize).
 //!
-nvinfer1::ITensor& convertToKTensor(TensorOrWeights& kInput, OnnxAttrs const& attrs, ImporterContext* ctx);
+nvinfer1::ITensor& convertToKTensor(
+    TensorOrWeights& kInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape = false);
 
 //!
 //! \brief Convert the input tensor to the V (value) tensor accepted by TensorRT.
@@ -55,9 +59,11 @@ nvinfer1::ITensor& convertToKTensor(TensorOrWeights& kInput, OnnxAttrs const& at
 //! \param vInput The input tensor to convert.
 //! \param attrs The attributes of the Attention node.
 //! \param ctx The importer context.
+//! \param needsReshape True if the input tensor needs to be reshaped to 4D, false otherwise.
 //! \return nvinfer1::ITensor& The converted V tensor with shape (batchSize, numHeads, sequenceLength, headSize).
 //!
-nvinfer1::ITensor& convertToVTensor(TensorOrWeights& vInput, OnnxAttrs const& attrs, ImporterContext* ctx);
+nvinfer1::ITensor& convertToVTensor(
+    TensorOrWeights& vInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape = false);
 
 //!
 //! \brief Convert the input tensor to the mask tensor accepted by TensorRT.
@@ -89,4 +95,13 @@ nvinfer1::ITensor& convertToMaskTensor(TensorOrWeights& maskInput, ImporterConte
 //!
 nvinfer1::AttentionNormalizationOp parseNormalizationOp(OnnxAttrs const& attrs);
 
+//!
+//! \brief Reshape the output tensor to the original input rank.
+//!
+//! \param tensor The output tensor to reshape.
+//! \param ctx The importer context.
+//! \param needsReshape True if the output tensor needs to be reshaped back to 3d, false otherwise.
+//! \return nvinfer1::ITensor& The reshaped output tensor.
+nvinfer1::ITensor& reshapeOutputTensor(
+    nvinfer1::ITensor& tensor, ImporterContext* ctx, bool const needsReshape = false);
 } // namespace onnx2trt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 # Version information
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 10)
-set(ONNX2TRT_MINOR 14)
-set(ONNX2TRT_PATCH 0)
+set(ONNX2TRT_MINOR 15)
+set(ONNX2TRT_PATCH 1)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 
 #--------------------------------------------------

--- a/ConditionalHelpers.cpp
+++ b/ConditionalHelpers.cpp
@@ -59,8 +59,9 @@ void addConditionalInputLayer(ImporterContext* ctx, nvinfer1::IIfConditional* co
 
 // Take a snapshot of the network before and after parsing the subgraph and return a list
 // of newly added network layers.
+// subgraphParentIdx is the index of the parent node in the main graph, used for error reporting.
 void importSubgraph(ImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const& subgraph,
-    std::vector<nvinfer1::ILayer*>& newLayers, std::vector<TensorOrWeights>& subgraphTensors)
+    std::vector<nvinfer1::ILayer*>& newLayers, std::vector<TensorOrWeights>& subgraphTensors, int32_t subgraphParentIdx)
 {
     auto net = ctx->network();
     int32_t beforeSubgraph = net->getNbLayers();
@@ -69,7 +70,8 @@ void importSubgraph(ImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const& su
     NameScope nameScope(*ctx);
 
     std::vector<Status> errors{};
-    onnx2trt::parseGraph(ctx, subgraph, errors);
+    onnx2trt::parseGraph(
+        ctx, subgraph, errors, /*deserializingINetwork=*/false, /*currentNode=*/nullptr, subgraphParentIdx);
 
     for (int32_t i = 0; i < subgraph.output_size(); ++i)
     {

--- a/ConditionalHelpers.hpp
+++ b/ConditionalHelpers.hpp
@@ -30,8 +30,10 @@ void getSubgraphInputs(const std::vector<nvinfer1::ILayer*>& newLayers, Subgraph
 
 // Take a snapshot of the network before and after parsing the subgraph and return a list
 // of newly added network layers.
+// subgraphParentIdx is the index of the parent node in the main graph, used for error reporting.
 void importSubgraph(ImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const& subgraph,
-    std::vector<nvinfer1::ILayer*>& newLayers, std::vector<TensorOrWeights>& subgraphTensors);
+    std::vector<nvinfer1::ILayer*>& newLayers, std::vector<TensorOrWeights>& subgraphTensors,
+    int32_t subgraphParentIdx = -1);
 
 // An InputsMap tracks which IIfConditionalInputLayer we've added to a layer's inputs,
 // so that we can reuse them if needed.

--- a/ImporterContext.cpp
+++ b/ImporterContext.cpp
@@ -269,8 +269,40 @@ void ImporterContext::registerLayer(
 
 void ImporterContext::registerLayer(nvinfer1::ILayer* layer, ::ONNX_NAMESPACE::NodeProto const& node)
 {
-    std::string const& basename = getNodeName(node);
-    registerLayer(layer, basename, &node);
+    registerLayer(layer, getNodeName(node), &node);
+}
+
+void ImporterContext::registerAttention(
+    nvinfer1::IAttention* attention, std::string const& basename, ::ONNX_NAMESPACE::NodeProto const* node)
+{
+    if (attention)
+    {
+        std::string const name = basename.empty() ? attention->getName() : basename;
+        std::string const& uniqueName = generateUniqueName(mLayerNames, mSuffixCounter, basename);
+
+        auto* ctx = this; // Logging macro uses ctx.
+        if (node != nullptr)
+        {
+            LOG_VERBOSE("Registering attention: " << uniqueName << " for ONNX node: " << basename);
+        }
+        else
+        {
+            LOG_VERBOSE("Registering attention: " << uniqueName << " required by ONNX-TRT");
+        }
+
+        attention->setName(uniqueName.c_str());
+    }
+
+    // Set metadata if the attention is associated with an ONNX node.
+    if (node != nullptr && attention != nullptr)
+    {
+        processMetadata(this, *node, attention);
+    }
+}
+
+void ImporterContext::registerAttention(nvinfer1::IAttention* attention, ::ONNX_NAMESPACE::NodeProto const& node)
+{
+    registerAttention(attention, getNodeName(node), &node);
 }
 
 void ImporterContext::addUsedVCPluginLibrary(
@@ -300,6 +332,23 @@ std::vector<std::string> ImporterContext::getUsedVCPluginLibraries()
     LOG_WARNING("getUsedVCPluginLibraries not implemented on platform!");
     return {};
 #endif
+}
+
+void ImporterContext::checkDLASupport(int32_t numPrevLayers, ::ONNX_NAMESPACE::NodeProto const& node, size_t const nodeIndex)
+{
+    for (int32_t i = numPrevLayers; i < network()->getNbLayers(); ++i)
+    {
+        auto* layer = network()->getLayer(i);
+        if (!mBuilderConfig->canRunOnDLA(layer))
+        {
+            ONNXTRT_THROW(MAKE_NODE_ERROR("DLA validation failed for layer: " + std::string(layer->getName()), ErrorCode::kUNSUPPORTED_NODE, node, nodeIndex));
+        }
+    }
+}
+
+[[nodiscard]] bool ImporterContext::getDLACapabilityMode() const
+{
+    return mOnnxParserFlags & (1U << static_cast<uint32_t>(nvonnxparser::OnnxParserFlag::kREPORT_CAPABILITY_DLA));
 }
 
 } // namespace onnx2trt

--- a/ImporterContext.hpp
+++ b/ImporterContext.hpp
@@ -79,6 +79,7 @@ class ImporterContext
 {
     nvinfer1::INetworkDefinition* mNetwork;
     nvinfer1::ILogger* mLogger;
+    nvinfer1::IBuilderConfig const* mBuilderConfig{nullptr};
     //! WeightsContext object to hold ownership of ONNX weights and any temporary weights created by the Parser.
     WeightsContext mWeightsContext;
     StringMap<int64_t> mOpsets;
@@ -216,6 +217,10 @@ public:
 
     void registerLayer(nvinfer1::ILayer* layer, std::string const& basename, ::ONNX_NAMESPACE::NodeProto const* node);
     void registerLayer(nvinfer1::ILayer* layer, ::ONNX_NAMESPACE::NodeProto const& node);
+
+    void registerAttention(
+        nvinfer1::IAttention* attention, std::string const& basename, ::ONNX_NAMESPACE::NodeProto const* node);
+    void registerAttention(nvinfer1::IAttention* attention, ::ONNX_NAMESPACE::NodeProto const& node);
 
     nvinfer1::ILogger& logger()
     {
@@ -392,6 +397,20 @@ public:
         assert(mNetwork != nullptr);
         return mNetwork->getFlag(nvinfer1::NetworkDefinitionCreationFlag::kSTRONGLY_TYPED);
     }
+    void setBuilderConfig(nvinfer1::IBuilderConfig const* builderConfig)
+    {
+        mBuilderConfig = builderConfig;
+    }
+    nvinfer1::IBuilderConfig const* getBuilderConfig() const
+    {
+        return mBuilderConfig;
+    }
+
+    // Called after each node is parsed to validate that added layers are supported on DLA.
+    // When kREPORT_CAPABILITY_DLA flag is set, it's expected that the parser will run layer validation.
+    void checkDLASupport(int32_t numPrevLayers, ::ONNX_NAMESPACE::NodeProto const& node, size_t const nodeIndex);
+
+    [[nodiscard]] bool getDLACapabilityMode() const;
 };
 
 typedef std::vector<TensorOrWeights> NodeOutputs;

--- a/LoopHelpers.cpp
+++ b/LoopHelpers.cpp
@@ -11,12 +11,13 @@ namespace onnx2trt
 nvinfer1::ITensor* addLoopCounter(ImporterContext* ctx, nvinfer1::ILoop* loop, int64_t initial)
 {
     nvinfer1::ITensor* initialTensor
-        = addConstantScalar(ctx, initial, ::ONNX_NAMESPACE::TensorProto::INT64, nvinfer1::Dims{1, {1}})->getOutput(0);
-    nvinfer1::ITensor* one = addConstantScalar(ctx, static_cast<int64_t>(1), ::ONNX_NAMESPACE::TensorProto::INT64,
-        nvinfer1::Dims{1, {1}})->getOutput(0);
+        = addConstantScalar(ctx, initial, ::ONNX_NAMESPACE::TensorProto::INT64, 1)->getOutput(0);
+    nvinfer1::ITensor* one
+        = addConstantScalar(ctx, static_cast<int64_t>(1), ::ONNX_NAMESPACE::TensorProto::INT64, 1)->getOutput(0);
 
     auto counter = N_CHECK(loop->addRecurrence(*initialTensor));
-    nvinfer1::ITensor* addOne = getElementWiseResult(ctx, *N_CHECK(counter->getOutput(0)), *one, nvinfer1::ElementWiseOperation::kSUM);
+    nvinfer1::ITensor* addOne
+        = getElementWiseResult(ctx, *N_CHECK(counter->getOutput(0)), *one, nvinfer1::ElementWiseOperation::kSUM);
     counter->setInput(1, *addOne);
     return N_CHECK(counter->getOutput(0));
 }

--- a/ModelImporter.cpp
+++ b/ModelImporter.cpp
@@ -131,12 +131,20 @@ void ModelImporter::logErrors()
         nvonnxparser::IParserError const* error = getError(i);
         if (error->node() != -1)
         {
-            ::ONNX_NAMESPACE::NodeProto const& node = mOnnxModel.graph().node(error->node());
-            LOG_ERROR("While parsing node number " << error->node() << " [" << node.op_type() << " -> \""
-                                                   << node.output(0) << "\""
-                                                   << "]:");
-            LOG_ERROR("--- Begin node ---" << "\n" << node);
-            LOG_ERROR("--- End node ---");
+            auto const& graph = mOnnxModel.graph();
+            if (error->node() >= 0 && error->node() < graph.node_size())
+            {
+                ::ONNX_NAMESPACE::NodeProto const& node = graph.node(error->node());
+                LOG_ERROR("While parsing node number " << error->node() << " [" << node.op_type() << " -> \""
+                                                       << node.output(0) << "\"" << "]:");
+                LOG_ERROR("--- Begin node ---" << "\n" << node);
+                LOG_ERROR("--- End node ---");
+            }
+            else
+            {
+                LOG_ERROR("While parsing node number "
+                    << error->node() << " (index out of bounds, graph size: " << graph.node_size() << ")");
+            }
         }
         LOG_ERROR("ERROR: " << error->file() << ":" << error->line() << " In function " << error->func() << ":\n"
                             << "[" << static_cast<int>(error->code()) << "] " << error->desc());
@@ -200,7 +208,7 @@ void ModelImporter::reportSubgraphs()
         // Add the node to the subgraph if:
         //     1. It is not directly connected to an unsupported input
         //     2. The importer function did not throw an assertion
-        bool unsupportedInput = (input_node.empty()) ? false : checkForInput(node);
+        bool unsupportedInput = !input_node.empty() && checkForInput(node);
         bool unsuccessfulParse = node_idx == error_node;
         if (!unsupportedInput && !unsuccessfulParse)
         {
@@ -223,7 +231,7 @@ void ModelImporter::reportSubgraphs()
         }
     }
     // Only one subgraph, mark it as true.
-    if (allSupported)
+    if (allSupported && mSubGraphSupportVector.size() == 1)
     {
         mSubGraphSupportVector.back().second = true;
     }
@@ -293,49 +301,66 @@ void parseNode(
         || (allowUint8Quantization && node.op_type() == "Constant"));
     skipUInt8Conversion
         |= (node.op_type() == "TRT_MXFP8QuantizeLinear" || node.op_type() == "TRT_MXFP8DequantizeLinear");
-    if (!skipUInt8Conversion)
-    {
-        for (auto& nodeInput : nodeInputs)
+
+        if (!skipUInt8Conversion)
         {
-            if (nodeInput.is_weights()
-                && nodeInput.weights().type == static_cast<int32_t>(::ONNX_NAMESPACE::TensorProto::UINT8))
+            for (auto& nodeInput : nodeInputs)
             {
-                auto weights = nodeInput.weights();
-                LOG_WARNING("UINT8 data " << weights.name << " is being converted to INT32.");
-                auto uint8_data = static_cast<uint8_t*>(weights.values);
-                int32_t* int32_data = ctx->getWeightsContext().convertUINT8(uint8_data, weights.shape);
-                auto int32ShapedWeights = ShapedWeights(
-                    static_cast<int32_t>(::ONNX_NAMESPACE::TensorProto::INT32), int32_data, weights.shape);
-                ctx->tensors()[std::string(weights.name)] = int32ShapedWeights;
-                nodeInput = int32ShapedWeights;
+                if (nodeInput.is_weights()
+                    && nodeInput.weights().type == static_cast<int32_t>(::ONNX_NAMESPACE::TensorProto::UINT8))
+                {
+                    auto weights = nodeInput.weights();
+                    LOG_WARNING("UINT8 data " << weights.name << " is being converted to INT32.");
+                    auto uint8_data = static_cast<uint8_t*>(weights.values);
+                    int32_t* int32_data = ctx->getWeightsContext().convertUINT8(uint8_data, weights.shape);
+                    auto int32ShapedWeights = ShapedWeights(
+                        static_cast<int32_t>(::ONNX_NAMESPACE::TensorProto::INT32), int32_data, weights.shape);
+                    ctx->tensors()[std::string(weights.name)] = int32ShapedWeights;
+                    nodeInput = int32ShapedWeights;
+                }
             }
         }
-    }
 
     // Dispatch to appropriate converter.
     NodeImporter const* importFunc{nullptr};
-    if (opImporters.count(nodeType))
+
+    // if the ENABLE_PLUGIN_OVERRIDE flag is set, then let the plugin override the standard ONNX operator
+    bool const pluginOverriding
+        = ctx->getFlags() & (1U << static_cast<uint32_t>(nvonnxparser::OnnxParserFlag::kENABLE_PLUGIN_OVERRIDE));
+    OnnxAttrs attrs(node, ctx);
+    bool const isPluginNode = attrs.count("plugin_namespace");
+
+    if (pluginOverriding || isPluginNode)
     {
-        importFunc = &opImporters.at(nodeType);
-    }
-    else if (ctx->localFunctions().count(nodeType))
-    {
-        // Let plugin take precedence over local function. So first check if this can be dispatched to a plugin.
         if (isNodeInPluginRegistry(ctx, node))
         {
-            LOG_VERBOSE("Found registered plugin: " << nodeType << ". Importing local function as a plugin.");
+            LOG_VERBOSE("Found registered plugin: " << nodeType << ". Importing this node as a plugin.");
             importFunc = &opImporters.at("FallbackPluginImporter");
         }
-        else
+    }
+
+    if (!importFunc)
+    {
+        if (opImporters.count(nodeType))
+        {
+            importFunc = &opImporters.at(nodeType);
+        }
+        // To be consistent with operator override, local function will be preferred over plugin if the flag is unset.
+        else if (ctx->localFunctions().count(nodeType))
         {
             LOG_VERBOSE("Found registered local function: " << nodeType << ". Importing as a local function.");
             importFunc = &opImporters.at("LocalFunctionImporter");
         }
+        else if (!pluginOverriding && !isPluginNode) // avoid to check Node in plugin registry again
+        {
+            LOG_VERBOSE("No importer registered for op: " << nodeType << ". Attempting to import as plugin.");
+            importFunc = &opImporters.at("FallbackPluginImporter");
+        }
     }
-    else
+    if (!importFunc)
     {
-        LOG_VERBOSE("No importer registered for op: " << nodeType << ". Attempting to import as plugin.");
-        importFunc = &opImporters.at("FallbackPluginImporter");
+        ONNXTRT_THROW(
+            MAKE_NODE_ERROR("No importer registered for op: " + nodeType, ErrorCode::kUNSUPPORTED_NODE, node, nodeIdx));
     }
 
     std::vector<TensorOrWeights> outputs;
@@ -493,7 +518,7 @@ void parseNodeStaticCheck(
 }
 
 void parseGraph(ImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const& graph, std::vector<Status>& errors,
-    bool deserializingINetwork, int* currentNode)
+    bool deserializingINetwork, int32_t* currentNode, int32_t subgraphParentIdx)
 {
     // Import initializers.
     try
@@ -528,11 +553,23 @@ void parseGraph(ImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const& graph,
         {
             *currentNode = nodeIndex;
         }
-        parseNodeStaticCheck(ctx, graph.node(nodeIndex), errors, nodeIndex);
+        // When parsing a subgraph, use the parent node index for error reporting.
+        // This ensures errors in subgraphs (e.g., Loop body) report the correct main-graph node index.
+        size_t const nodeIdxForErrors = (subgraphParentIdx >= 0) ? static_cast<size_t>(subgraphParentIdx) : nodeIndex;
+        parseNodeStaticCheck(ctx, graph.node(nodeIndex), errors, nodeIdxForErrors);
+
+        int32_t numPrevLayers = ctx->network()->getNbLayers();
+        // Parse the node
         if (errors.size() == 0)
         {
             // At most one dynamic error will be returned.
-            parseNode(ctx, graph.node(nodeIndex), nodeIndex, deserializingINetwork);
+            parseNode(ctx, graph.node(nodeIndex), nodeIdxForErrors, deserializingINetwork);
+        }
+
+        // Validate DLA support if kREPORT_CAPABILITY_DLA flag is set.
+        if (ctx->getDLACapabilityMode())
+        {
+            ctx->checkDLASupport(numPrevLayers, graph.node(nodeIndex), nodeIdxForErrors);
         }
     }
 
@@ -841,6 +878,13 @@ void ModelImporter::importModel()
     // Propagate OnnxParserFlags down to the importer context.
     mImporterCtx.setFlags(getFlags());
 
+    if (getFlag(nvonnxparser::OnnxParserFlag::kREPORT_CAPABILITY_DLA))
+    {
+        ONNXTRT_CHECK(ctx->getBuilderConfig(),
+            "A valid IBuilderConfig must be set when the kREPORT_CAPABILITY_DLA flag is set.",
+            ErrorCode::kINVALID_VALUE);
+    }
+
     mCurrentNode = -1;
     importInputs(&mImporterCtx, graph, &mImporterCtx.tensors(), mErrors);
     parseGraph(&mImporterCtx, graph, mErrors, mOnnxModel.producer_name() == "TensorRT", &mCurrentNode);
@@ -1094,4 +1138,20 @@ bool ModelImporter::parseModelProto() noexcept
     return false;
 }
 
+bool ModelImporter::setBuilderConfig(const nvinfer1::IBuilderConfig* const builderConfig) noexcept
+{
+    ONNXTRT_TRY
+    {
+        auto* const ctx = &mImporterCtx;
+        if (!builderConfig)
+        {
+            LOG_ERROR("Provided builder config is nullptr.");
+            return false;
+        }
+        ctx->setBuilderConfig(builderConfig);
+        return true;
+    }
+    ONNXTRT_CATCH_RECORD
+    return false;
+}
 } // namespace onnx2trt

--- a/ModelImporter.hpp
+++ b/ModelImporter.hpp
@@ -22,7 +22,7 @@ void parseNodeStaticCheck(
     ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, std::vector<Status>& errors, size_t const nodeIndex);
 
 void parseGraph(ImporterContext* ctx, ::ONNX_NAMESPACE::GraphProto const& graph, std::vector<Status>& errors,
-    bool deserializingINetwork = false, int32_t* currentNode = nullptr);
+    bool deserializingINetwork = false, int32_t* currentNode = nullptr, int32_t subgraphParentIdx = -1);
 
 class ModelImporter : public nvonnxparser::IParser
 {
@@ -159,6 +159,8 @@ public:
     bool loadInitializer(char const* name, void const* data, size_t size) noexcept override;
 
     bool parseModelProto() noexcept override;
+
+    bool setBuilderConfig(const nvinfer1::IBuilderConfig* const builderConfig) noexcept override;
 };
 
 } // namespace onnx2trt

--- a/ModelRefitter.cpp
+++ b/ModelRefitter.cpp
@@ -142,6 +142,7 @@ void ModelRefitter::refitOnnxGraph(::ONNX_NAMESPACE::GraphProto const& graph)
         {
             continue;
         }
+        LOG_REFITTER_VERBOSE("Refitting model initializer: " << initializer.name());
         // Remove the weight name from the set as some initializers
         // might have the same name across different nested constructs (e.g. IF nodes);
         // the assumption is that those weights would have the same value
@@ -214,13 +215,18 @@ void ModelRefitter::refitOnnxNode(::ONNX_NAMESPACE::NodeProto const& node, ::ONN
 
 void ModelRefitter::refitOnnxConstantOfShapeNode(::ONNX_NAMESPACE::NodeProto const& node, std::string const& graphName)
 {
-    ShapedWeights namedConstantOfShape = mWeightsContext.createNamedTempWeights(::ONNX_NAMESPACE::TensorProto::FLOAT, nvinfer1::Dims{1, {1}}, mTempRefittableWeights, mTempRefittableWeightsSuffixCounter, /*refittable=*/true);
+
+    ShapedWeights namedConstantOfShape = mWeightsContext.createNamedTempWeights(::ONNX_NAMESPACE::TensorProto::FLOAT,
+        nvinfer1::Dims{1, {1}}, mTempRefittableWeights, mTempRefittableWeightsSuffixCounter, /*refittable=*/true);
     std::string name = namedConstantOfShape.getName();
 
     if (!mRefittableWeights.count(name))
     {
         return;
     }
+
+    LOG_REFITTER_VERBOSE("Refitting ConstantOfShape node: " << node.name() << ", output: " << node.output(0));
+
     mRefittableWeights.erase(name);
     if (mRefittedWeights.count(name))
     {
@@ -254,10 +260,14 @@ void ModelRefitter::refitOnnxConstantOfShapeNode(::ONNX_NAMESPACE::NodeProto con
 
 void ModelRefitter::refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& node, std::string const& graphName)
 {
+
     if (!mRefittableWeights.count(node.output(0)))
     {
         return;
     }
+
+    LOG_REFITTER_VERBOSE("Refitting Constant node: " << node.name() << ", output: " << node.output(0));
+
     mRefittableWeights.erase(node.output(0));
     if (mRefittedWeights.count(node.output(0)))
     {
@@ -317,6 +327,8 @@ void ModelRefitter::refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& nod
 void ModelRefitter::refitOnnxBatchNormNode(
     ::ONNX_NAMESPACE::NodeProto const& node, ::ONNX_NAMESPACE::GraphProto const& graph)
 {
+    LOG_REFITTER_VERBOSE("Refitting BatchNorm node: " << node.name());
+
     ONNXTRT_CHECK(
         node.input().size() == 5, "BatchNorm node does not have five required inputs.", ErrorCode::kINVALID_NODE);
     std::vector<ShapedWeights> batchNormInputs;
@@ -370,6 +382,9 @@ void ModelRefitter::refitOnnxBatchNormNode(
 
 void ModelRefitter::refitOnnxIfNode(::ONNX_NAMESPACE::NodeProto const& node)
 {
+
+    LOG_REFITTER_VERBOSE("Refitting If node: " << node.name());
+
     size_t thenGraphOutputSize{};
     size_t elseGraphOutputSize{};
     for (auto const& attr : node.attribute())
@@ -397,12 +412,14 @@ void ModelRefitter::refitOnnxIfNode(::ONNX_NAMESPACE::NodeProto const& node)
 
 void ModelRefitter::refitOnnxLoopNode(::ONNX_NAMESPACE::NodeProto const& node)
 {
+    LOG_REFITTER_VERBOSE("Refitting Loop node: " << node.name());
     ::ONNX_NAMESPACE::GraphProto const& body = static_cast<::ONNX_NAMESPACE::GraphProto const&>(node.attribute(0).g());
     refitOnnxGraph(body);
 }
 
 void ModelRefitter::refitOnnxScanNode(::ONNX_NAMESPACE::NodeProto const& node)
 {
+    LOG_REFITTER_VERBOSE("Refitting Scan node: " << node.name());
     for (auto const& attr : node.attribute())
     {
         if (attr.name() == "body")

--- a/ModelRefitter.hpp
+++ b/ModelRefitter.hpp
@@ -25,6 +25,7 @@
         mLogger->log(severity, ss.str().c_str());                                                                      \
     } while (0)
 
+#define LOG_REFITTER_VERBOSE(msg) LOG_REFITTER(msg, nvinfer1::ILogger::Severity::kVERBOSE)
 #define LOG_REFITTER_WARNING(msg) LOG_REFITTER(msg, nvinfer1::ILogger::Severity::kWARNING)
 #define LOG_REFITTER_ERROR(msg) LOG_REFITTER(msg, nvinfer1::ILogger::Severity::kERROR)
 

--- a/NvOnnxParser.h
+++ b/NvOnnxParser.h
@@ -104,6 +104,16 @@ enum class OnnxParserFlag : int32_t
     //! in Quantize and Dequantize nodes. This flag is set to be OFF by default.
     //! The resulting engine must be built targeting DLA version >= 3.16.
     kENABLE_UINT8_AND_ASYMMETRIC_QUANTIZATION_DLA = 1,
+    //! Parse the ONNX model with per-node validation for DLA. If the model is not fully supported by DLA, then
+    //! parsing will fail. If this flag is set, isSubGraphSupported() will also return capability in the context of DLA
+    //! support. When this flag is set, a valid IBuilderConfig must be provided to the parser via setBuilderConfig().
+    // This flag is set to be OFF by default.
+    kREPORT_CAPABILITY_DLA = 2,
+    //! Allow a loaded plugin with the same name as an ONNX operator type to override the default ONNX implementation,
+    //! even if the plugin namespace attribute is not set.
+    //! Useful for custom plugins that replace standard ONNX operators, such as alternative implementations for better
+    //! performance. This flag is set to be OFF by default.
+    kENABLE_PLUGIN_OVERRIDE = 3
 };
 
 //!
@@ -114,7 +124,7 @@ enum class OnnxParserFlag : int32_t
 template <>
 constexpr inline int32_t EnumMax<OnnxParserFlag>() noexcept
 {
-    return 2;
+    return 3;
 }
 
 //!
@@ -460,6 +470,13 @@ public:
     //! \see getNbErrors() getError() loadModelProto() loadModelProtoFromFile()
     //!
     virtual bool parseModelProto() noexcept = 0;
+
+    //!
+    //! \brief Set the BuilderConfig for the parser.
+    //!
+    //! \return true if the IBuilderConfig was set successfully, false otherwise.
+    //!
+    virtual bool setBuilderConfig(const nvinfer1::IBuilderConfig* const builderConfig) noexcept = 0;
 };
 
 //!

--- a/OnnxAttrs.hpp
+++ b/OnnxAttrs.hpp
@@ -43,6 +43,11 @@ public:
         return _attrs.at(key);
     }
 
+    bool exists(std::string key) const
+    {
+        return _attrs.count(key) != 0;
+    }
+
     ::ONNX_NAMESPACE::AttributeProto::AttributeType type(std::string const& key) const
     {
         return this->at(key)->type();

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For press and other inquiries, please contact Hector Marinez at hmarinez@nvidia.
 
 ## Supported TensorRT Versions
 
-Development on the this branch is for the latest version of [TensorRT 10.14](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
+Development on the this branch is for the latest version of [TensorRT 10.15](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
 
 For previous versions of TensorRT, refer to their respective branches.
 
@@ -28,8 +28,8 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 
 ### Dependencies
 
- - [TensorRT 10.14](https://developer.nvidia.com/tensorrt)
- - [TensorRT 10.14 open source libraries](https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 10.15](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 10.15 open source libraries](https://github.com/NVIDIA/TensorRT/)
  - [Protobuf >= 3.20.3 (Optional)](https://github.com/google/protobuf/releases)
 
 ### Building
@@ -82,7 +82,7 @@ Refer to the link or run `polygraphy run -h` for more information on CLI options
 
 Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` files.
 
-TensorRT 10.14 supports ONNX release 1.18.0. Install it with:
+TensorRT 10.15 supports ONNX release 1.18.0. Install it with:
 
     python3 -m pip install onnx==1.18.0
 

--- a/RNNHelpers.cpp
+++ b/RNNHelpers.cpp
@@ -80,8 +80,7 @@ nvinfer1::ITensor* clearMissingSequenceElements(ImporterContext* ctx, const ::ON
     nvinfer1::ILoop* loop, nvinfer1::ITensor* seqLens, nvinfer1::ITensor* toMask, nvinfer1::ITensor* maxLen,
     bool reverse, nvinfer1::ITensor* counter)
 {
-    nvinfer1::ITensor* zero
-        = addConstantScalar(ctx, 0.f, ::ONNX_NAMESPACE::TensorProto::FLOAT, nvinfer1::Dims3(1, 1, 1))->getOutput(0);
+    nvinfer1::ITensor* zero = addConstantScalar(ctx, 0.f, ::ONNX_NAMESPACE::TensorProto::FLOAT, 3)->getOutput(0);
     nvinfer1::ITensor* seqMask = getRaggedMask(ctx, node, loop, seqLens, maxLen, reverse, counter);
     auto selectLayer = N_CHECK(ctx->network()->addSelect(*seqMask, *toMask, *zero));
     return N_CHECK(selectLayer->getOutput(0));

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,15 @@
 
 # ONNX-TensorRT Changelog
 
+# TensorRT 10.15 GA Release - 2026-2-2
+For more details, see the 10.15 GA release notes
+
+- Added support for `RotaryEmbedding`, `RMSNormalization` and `TensorScatter` for improved LLM model support
+- Added more specialized quantization ops for models quantized through TensorRT ModelOptimizer.
+- Added `kREPORT_CAPABILITY_DLA` flag to enable per-node validation when building DLA engines through TensorRT.
+- Added `kENABLE_PLUGIN_OVERRIDE` flag to enable TensorRT plugin override for nodes that share names with user plugins.
+- Improved error reporting for models with multiple subgraphs, such as `Loop` or `Scan` nodes.
+
 # TensorRT 10.14 GA Release - 2025-11-7
 For more details, see the 10.14 GA release notes
 

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -2,13 +2,13 @@
 
 # Supported ONNX Operators
 
-TensorRT 10.14 supports operators in the inclusive range of opset 9 to opset 24. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
+TensorRT 10.15 supports operators in the inclusive range of opset 9 to opset 24. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
 
 TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, FP8, FP4, INT32, INT64, INT8, INT4, UINT8, and BOOL
 
 > Note: There is limited support for DOUBLE type. TensorRT will attempt to cast DOUBLE down to FLOAT, clamping values to `+-FLT_MAX` if necessary.
 
-> Note: INT8, INT4, FP8 and FP4 are treated as `Quantized Types` in TensorRT, where support is available only through quantization from a floating-point type with higher precision. See [section 7.4.2](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#qat-models-work) of the developer guide for more information.
+> Note: INT8, INT4, FP8 and FP4 are treated as `Quantized Types` in TensorRT, where support is available only through quantization from a floating-point type with higher precision. See [our quantization guide](https://docs.nvidia.com/deeplearning/tensorrt/latest/inference-library/work-quantized-types.html) for more information.
 
 > Note: UINT8 is only supported as network input or output tensor types.
 
@@ -37,7 +37,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | BitwiseNot                | N          |
 | BitwiseOr                 | N          |
 | BitwiseXor                | N          |
-| BlackmanWindow            | Y          |
+| BlackmanWindow            | Y          | FP32, FP16 |
 | Cast                      | Y          | FP32, FP16, BF16, INT32, INT64, UINT8, BOOL |                                                                                                       |
 | CastLike                  | Y          | FP32, FP16, BF16, INT32, INT64, UINT8, BOOL |                                                                                                       |
 | Ceil                      | Y          | FP32, FP16, BF16 |
@@ -49,7 +49,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | Concat                    | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
 | ConcatFromSequence        | N          |
 | Constant                  | Y          | FP32, FP16, BF16, FP8, FP4, INT4, INT32, INT64, BOOL | `sparse_value`, `value_string`, and `value_strings` attributes are unsupported.
-| ConstantOfShape           | Y          | FP32, FP16, BF16, FP8, FP4, INT4, INT32, INF64, BOOL |
+| ConstantOfShape           | Y          | FP32, FP16, BF16, FP8, FP4, INT4, INT32, INT64, BOOL |
 | Conv                      | Y          | FP32, FP16, BF16 |
 | ConvInteger               | N          |
 | ConvTranspose             | Y          | FP32, FP16, BF16 |
@@ -62,7 +62,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | DequantizeLinear          | Y          | INT8, FP8, FP4, INT4 | `x_zero_point` must be zero                                                                                    |
 | Det                       | N          |
 | Div                       | Y          | FP32, FP16, BF16, INT32, INT64 |
-| Dropout                   | Y          | FP32, FP16, BF16 | `is_traning` must be an initializer and evaluate to False.
+| Dropout                   | Y          | FP32, FP16, BF16 | `is_training` must be an initializer and evaluate to False.
 | DynamicQuantizeLinear     | N          | Not supported. TensorRT's IDynamicQuantize can be composed from ONNX operators in the form of a model local function.
 | Einsum                    | Y          | FP32, FP16, BF16 |
 | Elu                       | Y          | FP32, FP16, BF16 |
@@ -86,8 +86,8 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | GridSample                | Y          | FP32, FP16 | Input must be 4D input.
 | GroupNormalization        | Y          | FP32, FP16, BF16 |
 | GRU                       | Y          | FP32, FP16, BF16 | For bidirectional GRUs, activation functions must be the same for both the forward and reverse pass
-| HammingWindow             | Y          |
-| HannWindow                | Y          |
+| HammingWindow             | Y          | FP32, FP16 |
+| HannWindow                | Y          | FP32, FP16 |
 | HardSigmoid               | Y          | FP32, FP16, BF16 |
 | HardSwish                 | Y          | FP32, FP16, BF16 |
 | Hardmax                   | Y          | FP32, FP16, BF16 | `axis` dimension of input must be a build-time constant
@@ -126,7 +126,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | Neg                       | Y          | FP32, FP16, BF16, INT32, INT64 |
 | NegativeLogLikelihoodLoss | N          |
 | NonMaxSuppression         | Y          | FP32, FP16 |
-| NonZero                   | Y          | FP32, FP16
+| NonZero                   | Y          | FP32, FP16 |
 | Not                       | Y          | BOOL |
 | OneHot                    | Y          | FP32, FP16, BF16, INT32, INT64, BOOL | `depth` must be a build-time constant
 | Optional                  | N          |
@@ -161,10 +161,12 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | Reshape                   | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
 | Resize                    | Y          | FP32, FP16, BF16 | Supported resize transformation modes: `half_pixel`, `pytorch_half_pixel`, `tf_half_pixel_for_nn`, `asymmetric`, and `align_corners`.<br />Supported resize modes: `nearest`, `linear`.<br />Supported nearest modes: `floor`, `ceil`, `round_prefer_floor`, `round_prefer_ceil`.<br />Supported aspect ratio policy: `stretch`.<br />When `scales` is a tensor input, `axes` must be an iota vector of length rank(input).<br />Antialiasing is not supported.|
 | ReverseSequence           | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |
+| RMSNormalization          | Y          | FP32, FP16, BF16 |
 | RNN                       | Y          | FP32, FP16, BF16| For bidirectional RNNs, activation functions must be the same for both the forward and reverse pass
 | RoiAlign                  | Y          | FP32, FP16 |
+| RotaryEmbedding           | Y          | FP32, FP16, BF16 | `position_ids` must be INT64 |
 | Round                     | Y          | FP32, FP16, BF16 |
-| STFT                      | Y          | FP32| `frame_step` and `window` must be an initializer. Input must be real-valued.
+| STFT                      | Y          | FP32 | `frame_step` and `window` must be an initializer. Input must be real-valued.
 | ScaledTanh                | Y          | FP32, FP16, BF16 |
 | Scan                      | Y          | FP32, FP16, BF16|
 | Scatter                   | Y          | FP32, FP16, BF16, INT32, INT64 |
@@ -202,6 +204,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | Sum                       | Y          | FP32, FP16, BF16, INT32, INT64 |
 | Tan                       | Y          | FP32, FP16, BF16 |
 | Tanh                      | Y          | FP32, FP16, BF16 |
+| TensorScatter             | Y          | FP32, FP16, BF16, INT32 | `past_cache` and `update` must be 4D. `axis` must be -2. |
 | TfIdfVectorizer           | N          |
 | ThresholdedRelu           | Y          | FP32, FP16, BF16 |
 | Tile                      | Y          | FP32, FP16, BF16, INT32, INT64, BOOL |

--- a/importerUtils.cpp
+++ b/importerUtils.cpp
@@ -1441,7 +1441,7 @@ TensorOrWeights identity(ImporterContext* ctx, TensorOrWeights input)
     }
 }
 
-nvinfer1::Dims makeDims(int nbDims, int val)
+nvinfer1::Dims makeDims(int32_t nbDims, int64_t val)
 {
     // Zero all the dimensions, so that unused dimensions are deterministic even if accidentally used.
     nvinfer1::Dims dims{nbDims, {}};
@@ -1450,7 +1450,7 @@ nvinfer1::Dims makeDims(int nbDims, int val)
 }
 
 NodeOutputs normalizationHelper(ImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node, size_t const nodeIdx,
-    std::vector<TensorOrWeights>& inputs)
+    std::vector<TensorOrWeights>& inputs, bool const useV2)
 {
     auto* input = &convertToTensor(inputs.at(0), ctx);
     auto* scale = &convertToTensor(inputs.at(1), ctx);
@@ -1487,7 +1487,7 @@ NodeOutputs normalizationHelper(ImporterContext* ctx, const ::ONNX_NAMESPACE::No
     scale = unsqueezeTensor(ctx, *scale, unsqueezeAxes);
     bias = unsqueezeTensor(ctx, *bias, unsqueezeAxes);
 
-    auto* layer = N_CHECK(ctx->network()->addNormalization(*input, *scale, *bias, axesMask));
+    auto* layer = useV2 ? N_CHECK(ctx->network()->addNormalizationV2(*input, *scale, *bias, axesMask)) : N_CHECK(ctx->network()->addNormalization(*input, *scale, *bias, axesMask));
     layer->setEpsilon(epsilon);
     layer->setNbGroups(nbGroups);
     ctx->registerLayer(layer, node);
@@ -2232,11 +2232,16 @@ NodeOutputs addScatterLayer(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto co
         }
     }
 
-    // TRT doesn't support int64 for indices
-    auto* cast = N_CHECK(ctx->network()->addCast(indices, nvinfer1::DataType::kINT32));
-    auto* indicesInt32 = N_CHECK(cast->getOutput(0));
+    // Only cast to INT32 for weakly-typed networks (strongly-typed supports INT64 indices)
+    nvinfer1::ITensor* indicesForScatter = &indices;
+    if (!ctx->isStronglyTyped() && indices.getType() == nvinfer1::DataType::kINT64)
+    {
+        auto* cast = N_CHECK(ctx->network()->addCast(indices, nvinfer1::DataType::kINT32));
+        indicesForScatter = N_CHECK(cast->getOutput(0));
+    }
 
-    auto* layer = N_CHECK(ctx->network()->addScatter(data, *indicesInt32, updates, mode));
+    auto* layer = N_CHECK(ctx->network()->addScatter(data, *indicesForScatter, updates, mode));
+
     layer->setAxis(axis);
     ctx->registerLayer(layer, node);
     auto output = N_CHECK(layer->getOutput(0));
@@ -2269,6 +2274,11 @@ nvinfer1::IElementWiseLayer* modWithFPInputs(ImporterContext* ctx, nvinfer1::ITe
     return N_CHECK(ctx->network()->addElementWise(*input0, *rhs, eOp::kSUB));
 }
 
+int32_t getNbDims(nvinfer1::ITensor const* tensor)
+{
+    return tensor->getDimensions().nbDims;
+}
+
 std::string truncateString(std::string const& s, int64_t limit)
 {
     if (static_cast<int64_t>(s.size()) <= limit)
@@ -2284,19 +2294,42 @@ void processMetadata(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& no
     // The format of the string is as follows:
     // [ONNX Layer: <name> | property1 | property2 | property3 ...]
 
-    std::string metadata = "[ONNX Layer: " + getNodeName(node);
+    std::ostringstream metadata;
+    metadata << "[ONNX Layer: " << getNodeName(node);
 
     // Generate local function stack string.
     for (auto it = ctx->localFunctionStack().crbegin(); it < ctx->localFunctionStack().crend(); ++it)
     {
-        metadata += " | " + it->nodeName + " (" + it->functionName + ")";
+        metadata << " | " << it->nodeName << " (" << it->functionName << ")";
     }
 
-    metadata += "]";
+    metadata << "]";
 
     // Truncate very long metadata since TRT API has a limit.
     constexpr int64_t kMETADATA_LIMIT{4000};
-    layer->setMetadata(truncateString(metadata, kMETADATA_LIMIT).c_str());
+    layer->setMetadata(truncateString(metadata.str(), kMETADATA_LIMIT).c_str());
+}
+
+void processMetadata(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, nvinfer1::IAttention* attention)
+{
+    // Create a docstring that holds node metadata and assign it to the corresponding IAttention.
+    // The format of the string is as follows:
+    // [ONNX Layer: <name> | property1 | property2 | property3 ...]
+
+    std::ostringstream metadata;
+    metadata << "[ONNX Layer: " << getNodeName(node);
+
+    // Generate local function stack string.
+    for (auto it = ctx->localFunctionStack().crbegin(); it < ctx->localFunctionStack().crend(); ++it)
+    {
+        metadata << " | " << it->nodeName << " (" << it->functionName << ")";
+    }
+
+    metadata << "]";
+
+    // Truncate very long metadata since TRT API has a limit.
+    constexpr int64_t kMETADATA_LIMIT{4000};
+    attention->setMetadata(truncateString(metadata.str(), kMETADATA_LIMIT).c_str());
 }
 
 nvinfer1::ITensor* generateWindow(ImporterContext* ctx, nvinfer1::ITensor* N)
@@ -2312,8 +2345,8 @@ nvinfer1::ITensor* generateWindow(ImporterContext* ctx, nvinfer1::ITensor* N)
 nvinfer1::ITensor* windowHelper(ImporterContext* ctx, float numerator, nvinfer1::ITensor* n, nvinfer1::ITensor* N,
     nvinfer1::UnaryOperation op, int32_t periodic)
 {
-    auto* numeratorTensor = N_CHECK(addConstantScalar(ctx, numerator, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
-        nvinfer1::Dims{1, {1}})->getOutput(0));
+    auto* numeratorTensor
+        = N_CHECK(addConstantScalar(ctx, numerator, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1)->getOutput(0));
     auto numeratorLayer
         = N_CHECK(ctx->network()->addElementWise(*numeratorTensor, *n, nvinfer1::ElementWiseOperation::kPROD));
     auto numeratorOutput = N_CHECK(numeratorLayer->getOutput(0));

--- a/importerUtils.hpp
+++ b/importerUtils.hpp
@@ -35,17 +35,20 @@ struct PluginDeleter
     void operator()(nvinfer1::IPluginV2* t);
 };
 
+// Helper function to create and fill a Dims object with defined values
+nvinfer1::Dims makeDims(int32_t nbDims, int64_t val);
+
 // Helper function to add a single constant value into TensorRT
 template <typename ScalarType>
 nvinfer1::IConstantLayer* addConstantScalar(
-    ImporterContext* ctx, ScalarType scalar, ShapedWeights::DataType type, nvinfer1::Dims shape = nvinfer1::Dims{0})
+    ImporterContext* ctx, ScalarType scalar, ShapedWeights::DataType type, int32_t nbDims = 0)
 {
     ONNXTRT_CHECK(getShapedWeightsDataType<ScalarType>() == type, "Found type mismatch when creating scalar value",
         ErrorCode::kINTERNAL_ERROR);
-    ONNXTRT_CHECK(volume(shape) == 1,
-        "Cannot add constant scalar with a shape that has volume > 1. Provided volume: " << volume(shape),
-        ErrorCode::kINTERNAL_ERROR);
-    ShapedWeights scalarWeights = ctx->createNamedTempWeights(type, shape);
+    ONNXTRT_CHECK(nbDims >= 0 && nbDims <= nvinfer1::Dims::MAX_DIMS,
+        "nbDims must be between 0 and " << nvinfer1::Dims::MAX_DIMS, ErrorCode::kINTERNAL_ERROR);
+    nvinfer1::Dims const dims = makeDims(nbDims, 1);
+    ShapedWeights scalarWeights = ctx->createNamedTempWeights(type, dims);
     static_cast<ScalarType*>(scalarWeights.values)[0] = static_cast<ScalarType>(scalar);
     nvinfer1::IConstantLayer* l = N_CHECK(ctx->network()->addConstant(scalarWeights.shape, scalarWeights));
     ctx->network()->setWeightsName(scalarWeights, scalarWeights.getName());
@@ -268,12 +271,9 @@ std::unique_ptr<nvinfer1::IPluginV3> createPlugin(ImporterContext* ctx, ::ONNX_N
 // Helper function to return the identity of a TensorOrWeights
 TensorOrWeights identity(ImporterContext* ctx, TensorOrWeights input);
 
-// Helper function to create and fill a Dims object with defined values
-nvinfer1::Dims makeDims(int nbDims, int val);
-
 // Helper function to create normalization layers for GroupNorm and InstanceNorm
 NodeOutputs normalizationHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, size_t const nodeIdx,
-    std::vector<TensorOrWeights>& inputs);
+    std::vector<TensorOrWeights>& inputs, bool const useV2);
 
 // Given a list of axes in the range of [-rank, rank-1], where rank is the rank
 // of the corresponding data tensor, normalize to [0, rank-1].
@@ -407,6 +407,9 @@ nvinfer1::IElementWiseLayer* modWithIntegerInputs(
 nvinfer1::IElementWiseLayer* modWithFPInputs(ImporterContext* ctx, nvinfer1::ITensor* input0, nvinfer1::ITensor* input1,
     nvinfer1::ITensor* divResult, bool sameSign);
 
+//! Helper function to get the number of dimensions of a tensor.
+int32_t getNbDims(nvinfer1::ITensor const* tensor);
+
 //! RAII wrapper for ImporterContext::pushBaseNameScope() and popBaseNameScope().
 class NameScope
 {
@@ -432,7 +435,12 @@ Status notInvalidType(TensorOrWeights const& input, std::vector<std::string> con
 void checkNotInvalidType(TensorOrWeights const& input, std::vector<std::string> const& invalidTypes,
     ::ONNX_NAMESPACE::NodeProto const& node, size_t const nodeIdx);
 
+// Helper function to truncate string to length limit
+std::string truncateString(std::string const& s, int64_t limit);
+
 void processMetadata(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, nvinfer1::ILayer* layer);
+
+void processMetadata(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, nvinfer1::IAttention* attention);
 
 // Helper function to convert TensorRT datatype enum into a human-readable string.
 std::string getTrtDtypeName(nvinfer1::DataType TrtDtype);

--- a/onnxOpCheckers.cpp
+++ b/onnxOpCheckers.cpp
@@ -183,6 +183,8 @@ DEFINE_OP_CHECKER(Attention)
         ErrorCode::kUNSUPPORTED_NODE, node, errors, nodeIndex);
 }
 
+DEFINE_OP_EMPTY_CHECKER(TRT_QuantizedAttention)
+
 DEFINE_OP_EMPTY_CHECKER(Add)
 
 DEFINE_OP_CHECKER(ArgMax)
@@ -276,6 +278,7 @@ DEFINE_OP_EMPTY_CHECKER(QuantizeLinear)
 DEFINE_OP_EMPTY_CHECKER(DequantizeLinear)
 
 
+
 DEFINE_OP_EMPTY_CHECKER(TRT_FP8QuantizeLinear)
 
 DEFINE_OP_EMPTY_CHECKER(TRT_FP8DequantizeLinear)
@@ -285,6 +288,12 @@ DEFINE_OP_EMPTY_CHECKER(TRT_INT4QuantizeLinear)
 DEFINE_OP_EMPTY_CHECKER(TRT_INT4DequantizeLinear)
 
 DEFINE_OP_EMPTY_CHECKER(TRT_FP4DynamicQuantize)
+
+DEFINE_OP_EMPTY_CHECKER(TRT_DynamicQuantize)
+
+DEFINE_OP_EMPTY_CHECKER(TRT_BlockQuantize)
+
+DEFINE_OP_EMPTY_CHECKER(TRT_BlockDequantize)
 
 DECLARE_OP_CHECKER(Mul);
 
@@ -601,6 +610,8 @@ DEFINE_OP_EMPTY_CHECKER(ReduceSumSquare)
 
 DEFINE_OP_EMPTY_CHECKER(Relu)
 
+DEFINE_OP_EMPTY_CHECKER(RMSNormalization)
+
 DEFINE_OP_EMPTY_CHECKER(Sign)
 
 
@@ -723,6 +734,8 @@ DEFINE_OP_CHECKER(RoiAlign)
     }
 }
 
+DEFINE_OP_EMPTY_CHECKER(RotaryEmbedding)
+
 DEFINE_OP_EMPTY_CHECKER(ScaledTanh)
 
 DEFINE_OP_EMPTY_CHECKER(Scan)
@@ -780,6 +793,8 @@ DEFINE_OP_EMPTY_CHECKER(Tan)
 
 DEFINE_OP_EMPTY_CHECKER(Tanh)
 
+DEFINE_OP_EMPTY_CHECKER(TensorScatter)
+
 DEFINE_OP_EMPTY_CHECKER(ThresholdedRelu)
 
 DEFINE_OP_EMPTY_CHECKER(Tile)
@@ -835,7 +850,10 @@ DEFINE_OP_CHECKER(FallbackPluginImporter)
     // Fallback check to the node's domain
     if (!creator)
     {
-        LOG_INFO("Searching for plugin wth node domain namespace: " << pluginNamespace);
+        LOG_INFO("Plugin not found with node attribute namespace: using pluginName: "
+            << pluginName << ", pluginVersion: " << pluginVersion << ", pluginNamespace: " << pluginNamespace);
+        LOG_INFO("Searching for plugin with node domain namespace: using pluginName: "
+            << pluginName << ", pluginVersion: " << pluginVersion << ", pluginNamespace: " << node.domain());
         pluginNamespace = node.domain();
         creator = importPluginCreator(ctx, pluginName, pluginVersion, pluginNamespace);
     }

--- a/onnxOpImporters.cpp
+++ b/onnxOpImporters.cpp
@@ -189,10 +189,16 @@ DEFINE_BUILTIN_OP_IMPORTER(Attention)
 
     OnnxAttrs attrs(node, ctx);
 
+    ONNXTRT_CHECK_NODE(inputs.at(0).shape().nbDims == inputs.at(1).shape().nbDims
+            && inputs.at(0).shape().nbDims == inputs.at(2).shape().nbDims,
+        "Q, K, and V inputs must have the same number of dimensions.", node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+    // 3D case needs to be reshaped to 4D.
+    bool const needsReshape = inputs.at(0).shape().nbDims == 3;
+
     // Get inputs.
-    nvinfer1::ITensor& query = convertToQTensor(inputs.at(0), attrs, ctx);
-    nvinfer1::ITensor& key = convertToKTensor(inputs.at(1), attrs, ctx);
-    nvinfer1::ITensor& value = convertToVTensor(inputs.at(2), attrs, ctx);
+    nvinfer1::ITensor& query = convertToQTensor(inputs.at(0), attrs, ctx, needsReshape);
+    nvinfer1::ITensor& key = convertToKTensor(inputs.at(1), attrs, ctx, needsReshape);
+    nvinfer1::ITensor& value = convertToVTensor(inputs.at(2), attrs, ctx, needsReshape);
     bool const hasAttnMask = inputs.size() > 3 && !inputs.at(3).isNullTensor();
     bool const hasPastKey = inputs.size() > 4 && !inputs.at(4).isNullTensor();
     bool const hasPastValue = inputs.size() > 5 && !inputs.at(5).isNullTensor();
@@ -209,7 +215,66 @@ DEFINE_BUILTIN_OP_IMPORTER(Attention)
 
     // Add the Attention layer.
     nvinfer1::IAttention* attention = N_CHECK(ctx->network()->addAttention(query, key, value, normOp, isCausal));
+    ctx->registerAttention(attention, node);
     attention->setDecomposable(decomposable);
+
+    if (hasAttnMask)
+    {
+        attention->setMask(convertToMaskTensor(inputs.at(3), ctx));
+    }
+
+    return {{&reshapeOutputTensor(*attention->getOutput(0), ctx, needsReshape)}};
+}
+
+DEFINE_BUILTIN_OP_IMPORTER(TRT_QuantizedAttention)
+{
+    OnnxAttrs attrs(node, ctx);
+
+    auto normQuantizeToTypeOnnx
+        = attrs.get<int32_t>("normalization_quantize_to_type", ::ONNX_NAMESPACE::TensorProto::UNDEFINED);
+    DataType normQuantizeToType;
+    if (normQuantizeToTypeOnnx == ::ONNX_NAMESPACE::TensorProto::UNDEFINED)
+    {
+        LOG_WARNING("normalization_quantize_to_type is not set. Defaulting to FP8.");
+        normQuantizeToType = DataType::kFP8;
+    }
+    else
+    {
+        ONNXTRT_CHECK_NODE(convertDtype(normQuantizeToTypeOnnx, &normQuantizeToType),
+            "Attribute normalization_quantize_to_type specifies an unsupported data type " << normQuantizeToType << ".",
+            node, nodeIdx, nvonnxparser::ErrorCode::kUNSUPPORTED_NODE);
+        ONNXTRT_CHECK_NODE(normQuantizeToType == DataType::kFP8 || normQuantizeToType == DataType::kINT8,
+            "normalization_quantize_to_type must be FP8 or INT8.", node, nodeIdx,
+            nvonnxparser::ErrorCode::kUNSUPPORTED_NODE);
+    }
+
+    bool const isCausal = static_cast<bool>(attrs.get<int64_t>("is_causal", 0));
+    nvinfer1::AttentionNormalizationOp const normOp = parseNormalizationOp(attrs);
+    bool const decomposable = static_cast<bool>(attrs.get<int64_t>("TRT_decomposable", 0));
+
+    ONNXTRT_CHECK_NODE(inputs.size() == 5, "Quantized Attention requires 5 inputs.", node, nodeIdx,
+        nvonnxparser::ErrorCode::kUNSUPPORTED_NODE);
+
+    ONNXTRT_CHECK_NODE(inputs.at(0).shape().nbDims == inputs.at(1).shape().nbDims
+            && inputs.at(0).shape().nbDims == inputs.at(2).shape().nbDims,
+        "Q, K, and V inputs must have the same number of dimensions.", node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+
+    ONNXTRT_CHECK_NODE(inputs.at(0).shape().nbDims == 4, "Quantized Attention only supports 4D inputs.", node, nodeIdx,
+        nvonnxparser::ErrorCode::kUNSUPPORTED_NODE);
+
+    // Get inputs.
+    nvinfer1::ITensor& query = convertToQTensor(inputs.at(0), attrs, ctx);
+    nvinfer1::ITensor& key = convertToKTensor(inputs.at(1), attrs, ctx);
+    nvinfer1::ITensor& value = convertToVTensor(inputs.at(2), attrs, ctx);
+    bool const hasAttnMask = !inputs.at(3).isNullTensor();
+    nvinfer1::ITensor& normalizationQuantizeScale = convertToTensor(inputs.at(4), ctx);
+
+    // Add the Attention layer.
+    nvinfer1::IAttention* attention = N_CHECK(ctx->network()->addAttention(query, key, value, normOp, isCausal));
+    ctx->registerAttention(attention, node);
+    attention->setDecomposable(decomposable);
+    attention->setNormalizationQuantizeToType(normQuantizeToType);
+    attention->setNormalizationQuantizeScale(normalizationQuantizeScale);
 
     if (hasAttnMask)
     {
@@ -246,7 +311,7 @@ NodeOutputs batchnormFallback(
     using uOp = nvinfer1::UnaryOperation;
 
     nvinfer1::ITensor& input = convertToTensor(inputs.at(0), ctx);
-    int32_t const rank = input.getDimensions().nbDims;
+    int32_t const rank = getNbDims(&input);
 
     std::array<nvinfer1::ITensor*, 4> tensors = {
         &convertToTensor(inputs.at(1), ctx),
@@ -274,24 +339,20 @@ NodeOutputs batchnormFallback(
     OnnxAttrs attrs(node, ctx);
     float eps = attrs.get<float>("epsilon", 1e-5F);
 
-    nvinfer1::Dims scalarShape{rank};
-    std::fill(scalarShape.d, scalarShape.d + scalarShape.nbDims, 1);
-
     auto varType = variance->getType();
     nvinfer1::IConstantLayer* epsLayer;
     if (varType == DataType::kHALF)
     {
-        epsLayer = addConstantScalar(
-            ctx, static_cast<half_float::half>(eps), ::ONNX_NAMESPACE::TensorProto::FLOAT16, scalarShape);
+        epsLayer
+            = addConstantScalar(ctx, static_cast<half_float::half>(eps), ::ONNX_NAMESPACE::TensorProto::FLOAT16, rank);
     }
     else if (varType == DataType::kBF16)
     {
-        epsLayer
-            = addConstantScalar(ctx, static_cast<BFloat16>(eps), ::ONNX_NAMESPACE::TensorProto::BFLOAT16, scalarShape);
+        epsLayer = addConstantScalar(ctx, static_cast<BFloat16>(eps), ::ONNX_NAMESPACE::TensorProto::BFLOAT16, rank);
     }
     else
     {
-        epsLayer = addConstantScalar(ctx, eps, ::ONNX_NAMESPACE::TensorProto::FLOAT, scalarShape);
+        epsLayer = addConstantScalar(ctx, eps, ::ONNX_NAMESPACE::TensorProto::FLOAT, rank);
     }
     nvinfer1::ITensor* epsilon = N_CHECK(epsLayer->getOutput(0));
 
@@ -468,21 +529,21 @@ DEFINE_BUILTIN_OP_IMPORTER(BlackmanWindow)
 
     auto lhsCosOutput = windowHelper(ctx, 2.F * M_PI, window, N, nvinfer1::UnaryOperation::kCOS, periodic);
 
-    auto betaTensor = N_CHECK(addConstantScalar(ctx, beta, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
-        nvinfer1::Dims{1, {1}})->getOutput(0));
+    auto betaTensor
+        = N_CHECK(addConstantScalar(ctx, beta, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1)->getOutput(0));
     auto betaLayer
         = N_CHECK(ctx->network()->addElementWise(*betaTensor, *lhsCosOutput, nvinfer1::ElementWiseOperation::kPROD));
     auto betaOutput = N_CHECK(betaLayer->getOutput(0));
 
     auto rhsCosOutput = windowHelper(ctx, 4.F * M_PI, window, N, nvinfer1::UnaryOperation::kCOS, periodic);
-    auto gammaTensor = N_CHECK(addConstantScalar(ctx, gamma, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
-        nvinfer1::Dims{1, {1}})->getOutput(0));
+    auto gammaTensor
+        = N_CHECK(addConstantScalar(ctx, gamma, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1)->getOutput(0));
     auto gammaLayer
         = N_CHECK(ctx->network()->addElementWise(*gammaTensor, *rhsCosOutput, nvinfer1::ElementWiseOperation::kPROD));
     auto gammaOutput = N_CHECK(gammaLayer->getOutput(0));
 
-    auto alphaTensor = N_CHECK(addConstantScalar(ctx, alpha, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
-        nvinfer1::Dims{1, {1}})->getOutput(0));
+    auto alphaTensor
+        = N_CHECK(addConstantScalar(ctx, alpha, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1)->getOutput(0));
     auto alphaMinusBeta
         = N_CHECK(ctx->network()->addElementWise(*alphaTensor, *betaOutput, nvinfer1::ElementWiseOperation::kSUB));
     auto alphaMinusBetaTensor = N_CHECK(alphaMinusBeta->getOutput(0));
@@ -624,19 +685,21 @@ NodeOutputs elementwiseClipHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::NodePr
 {
     OnnxAttrs attrs(node, ctx);
     auto* input = &convertToTensor(inputs.at(0), ctx);
+    int32_t const nbDims = getNbDims(input);
     nvinfer1::ITensor* alphaT{nullptr};
     nvinfer1::ITensor* betaT{nullptr};
     ScalarType alpha = std::numeric_limits<ScalarType>::lowest();
     ScalarType beta = std::numeric_limits<ScalarType>::max();
     if (numInputs == 1)
     {
-        alphaT = N_CHECK(addConstantScalar(ctx, alpha, onnxType)->getOutput(0));
-        betaT = N_CHECK(addConstantScalar(ctx, beta, onnxType)->getOutput(0));
+        alphaT = N_CHECK(addConstantScalar(ctx, alpha, onnxType, nbDims)->getOutput(0));
+        betaT = N_CHECK(addConstantScalar(ctx, beta, onnxType, nbDims)->getOutput(0));
     }
     else if (numInputs == 2)
     {
         alphaT = &convertToTensor(inputs.at(1), ctx);
-        betaT = N_CHECK(addConstantScalar(ctx, beta, onnxType)->getOutput(0));
+        broadcastTensors(ctx, input, alphaT);
+        betaT = N_CHECK(addConstantScalar(ctx, beta, onnxType, nbDims)->getOutput(0));
     }
     else if (numInputs == 3)
     {
@@ -644,25 +707,25 @@ NodeOutputs elementwiseClipHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::NodePr
         if (!inputs.at(1).isNullTensor())
         {
             alphaT = &convertToTensor(inputs.at(1), ctx);
+            broadcastTensors(ctx, input, alphaT);
         }
         else
         {
-            alphaT = N_CHECK(addConstantScalar(ctx, alpha, onnxType)->getOutput(0));
+            alphaT = N_CHECK(addConstantScalar(ctx, alpha, onnxType, nbDims)->getOutput(0));
         }
         if (!inputs.at(2).isNullTensor())
         {
             betaT = &convertToTensor(inputs.at(2), ctx);
+            broadcastTensors(ctx, input, betaT);
         }
         else
         {
-            betaT = N_CHECK(addConstantScalar(ctx, beta, onnxType)->getOutput(0));
+            betaT = N_CHECK(addConstantScalar(ctx, beta, onnxType, nbDims)->getOutput(0));
         }
     }
 
     // Now that we have alphaT and betaT, do the elementwise calculation
     using eOp = nvinfer1::ElementWiseOperation;
-    broadcastTensors(ctx, input, alphaT);
-    broadcastTensors(ctx, input, betaT);
     auto* lowerClipLayer = N_CHECK(ctx->network()->addElementWise(*input, *alphaT, eOp::kMAX));
     auto* lowerClip = N_CHECK(lowerClipLayer->getOutput(0));
     auto* upperClipLayer = N_CHECK(ctx->network()->addElementWise(*lowerClip, *betaT, eOp::kMIN));
@@ -1859,6 +1922,155 @@ DEFINE_BUILTIN_OP_IMPORTER(TRT_FP4DynamicQuantize)
     RETURN_ALL_OUTPUTS(dq, node, nodeIdx);
 }
 
+static nvinfer1::Dims getBlockShape(OnnxAttrs attrs, ::ONNX_NAMESPACE::NodeProto const& node, size_t const nodeIdx)
+{
+    auto const blockShapeOnnx = attrs.get<std::vector<int32_t>>("block_shape");
+    ONNXTRT_CHECK_NODE(!blockShapeOnnx.empty() && blockShapeOnnx.size() <= nvinfer1::Dims::MAX_DIMS,
+        "block_shape must be non-empty and not exceed " << nvinfer1::Dims::MAX_DIMS << " dimensions.", node, nodeIdx,
+        nvonnxparser::ErrorCode::kINVALID_NODE);
+    nvinfer1::Dims blockShape;
+    blockShape.nbDims = static_cast<int32_t>(blockShapeOnnx.size());
+    std::copy_n(blockShapeOnnx.begin(), blockShape.nbDims, blockShape.d);
+    return blockShape;
+}
+
+DEFINE_BUILTIN_OP_IMPORTER(TRT_BlockQuantize)
+{
+    nvinfer1::ITensor* dataInput = &convertToTensor(inputs.at(0), ctx);
+    nvinfer1::ITensor* scaleInput = &convertToTensor(inputs.at(1), ctx);
+
+    OnnxAttrs attrs(node, ctx);
+
+    auto const outputTypeOnnx = attrs.get<int32_t>("output_dtype", ::ONNX_NAMESPACE::TensorProto::UNDEFINED);
+
+    DataType outputType;
+    bool isOutputTypeSet = (outputTypeOnnx != ::ONNX_NAMESPACE::TensorProto::UNDEFINED);
+    if (isOutputTypeSet)
+    {
+        isOutputTypeSet = convertDtype(outputTypeOnnx, &outputType);
+        ONNXTRT_CHECK_NODE(isOutputTypeSet,
+            "Attribute output_dtype specifies an unsupported data type " << outputTypeOnnx << ".", node, nodeIdx,
+            nvonnxparser::ErrorCode::kUNSUPPORTED_NODE);
+    }
+    else
+    {
+        LOG_WARNING("output_dtype is not set. Defaulting to FP8.");
+        outputType = DataType::kFP8;
+    }
+
+    nvinfer1::Dims blockShape = getBlockShape(attrs, node, nodeIdx);
+    nvinfer1::IQuantizeLayer* q = N_CHECK(ctx->network()->addQuantize(*dataInput, *scaleInput, outputType));
+    q->setBlockShape(blockShape);
+    ctx->registerLayer(q, node);
+
+    RETURN_ALL_OUTPUTS(q, node, nodeIdx);
+}
+
+DEFINE_BUILTIN_OP_IMPORTER(TRT_BlockDequantize)
+{
+    nvinfer1::ITensor* dataInput = &convertToTensor(inputs.at(0), ctx);
+    nvinfer1::ITensor* scaleInput = &convertToTensor(inputs.at(1), ctx);
+
+    OnnxAttrs attrs(node, ctx);
+
+    auto const outputTypeOnnx = attrs.get<int32_t>("output_dtype", ::ONNX_NAMESPACE::TensorProto::UNDEFINED);
+
+    DataType outputType;
+    bool isOutputTypeSet = (outputTypeOnnx != ::ONNX_NAMESPACE::TensorProto::UNDEFINED);
+    if (isOutputTypeSet)
+    {
+        isOutputTypeSet = convertDtype(outputTypeOnnx, &outputType);
+        ONNXTRT_CHECK_NODE(isOutputTypeSet,
+            "Attribute output_dtype specifies an unsupported data type " << outputTypeOnnx << ".", node, nodeIdx,
+            nvonnxparser::ErrorCode::kUNSUPPORTED_NODE);
+    }
+    else
+    {
+        LOG_WARNING("output_dtype is not set. Defaulting to scale type.");
+        outputType = scaleInput->getType();
+    }
+
+    nvinfer1::Dims blockShape = getBlockShape(attrs, node, nodeIdx);
+    nvinfer1::IDequantizeLayer* dq = N_CHECK(ctx->network()->addDequantize(*dataInput, *scaleInput, outputType));
+    dq->setBlockShape(blockShape);
+    ctx->registerLayer(dq, node);
+
+    RETURN_ALL_OUTPUTS(dq, node, nodeIdx);
+}
+
+DEFINE_BUILTIN_OP_IMPORTER(TRT_DynamicQuantize)
+{
+    nvinfer1::ITensor* dataInput = &convertToTensor(inputs.at(0), ctx);
+    nvinfer1::ITensor* scaleInput = inputs.size() > 1 ? &convertToTensor(inputs.at(1), ctx) : nullptr;
+
+    OnnxAttrs attrs(node, ctx);
+
+    auto const blockShapeOnnx = attrs.get<std::vector<int32_t>>("block_shape");
+    auto const scaleTypeOnnx = attrs.get<int32_t>("scale_type", ::ONNX_NAMESPACE::TensorProto::UNDEFINED);
+    auto const outputTypeOnnx = attrs.get<int32_t>("output_type", ::ONNX_NAMESPACE::TensorProto::UNDEFINED);
+
+    DataType scaleType;
+    bool isScaleTypeSet = (scaleTypeOnnx != ::ONNX_NAMESPACE::TensorProto::UNDEFINED);
+    if (isScaleTypeSet)
+    {
+        isScaleTypeSet = convertDtype(scaleTypeOnnx, &scaleType);
+        ONNXTRT_CHECK_NODE(isScaleTypeSet,
+            "Attribute scale_type specifies an unsupported data type " << scaleType << ".", node, nodeIdx,
+            nvonnxparser::ErrorCode::kUNSUPPORTED_NODE);
+    }
+    else
+    {
+        LOG_WARNING("scale_type is not set. Defaulting to Float.");
+        scaleType = DataType::kFLOAT;
+    }
+
+    DataType outputType;
+    bool isOutputTypeSet = (outputTypeOnnx != ::ONNX_NAMESPACE::TensorProto::UNDEFINED);
+    if (isOutputTypeSet)
+    {
+        isOutputTypeSet = convertDtype(outputTypeOnnx, &outputType);
+        ONNXTRT_CHECK_NODE(isOutputTypeSet,
+            "Attribute output_type specifies an unsupported data type " << outputType << ".", node, nodeIdx,
+            nvonnxparser::ErrorCode::kUNSUPPORTED_NODE);
+    }
+    else
+    {
+        LOG_WARNING("output_type is not set. Defaulting to FLOAT.");
+        outputType = DataType::kFLOAT;
+    }
+
+    nvinfer1::Dims blockSizeDims;
+    ONNXTRT_CHECK_NODE(!blockShapeOnnx.empty() && blockShapeOnnx.size() <= nvinfer1::Dims::MAX_DIMS,
+        "block_shape must be non-empty and not exceed " << nvinfer1::Dims::MAX_DIMS << " dimensions.", node, nodeIdx,
+        nvonnxparser::ErrorCode::kINVALID_NODE);
+
+    blockSizeDims.nbDims = static_cast<int32_t>(blockShapeOnnx.size());
+    for (int32_t i = 0; i < blockSizeDims.nbDims; ++i)
+    {
+        ONNXTRT_CHECK_NODE(blockShapeOnnx[i] >= -1, "block_shape values must be >= -1.", node, nodeIdx,
+            nvonnxparser::ErrorCode::kINVALID_NODE);
+        blockSizeDims.d[i] = blockShapeOnnx[i];
+    }
+
+    if (inputs.size() > 1)
+    {
+        ONNXTRT_CHECK_NODE(inputs.at(1).is_weights(), "Scale input must be an initializer.", node, nodeIdx,
+            nvonnxparser::ErrorCode::kUNSUPPORTED_NODE);
+        ONNXTRT_CHECK_NODE(inputs.at(1).weights().count() == 1, "Scale input must be a scalar.", node, nodeIdx,
+            nvonnxparser::ErrorCode::kUNSUPPORTED_NODE);
+    }
+
+    nvinfer1::IDynamicQuantizeLayer* dynq
+        = N_CHECK(ctx->network()->addDynamicQuantizeV2(*dataInput, blockSizeDims, outputType, scaleType));
+    if (scaleInput)
+    {
+        dynq->setInput(1, *scaleInput);
+    }
+    ctx->registerLayer(dynq, node);
+
+    RETURN_ALL_OUTPUTS(dynq, node, nodeIdx);
+}
+
 DEFINE_BUILTIN_OP_IMPORTER(QuantizeLinear)
 {
     return QuantDequantLinearHelper(ctx, node, nodeIdx, inputs, false /*isDQ*/, false /*isCustomOp*/);
@@ -2283,9 +2495,8 @@ DEFINE_BUILTIN_OP_IMPORTER(Gemm)
     if (alpha != 1.f)
     {
         nvinfer1::IConstantLayer* alphaConstant
-            = addConstantScalar(ctx, alpha, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+            = addConstantScalar(ctx, alpha, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, getNbDims(matmulTensor));
         nvinfer1::ITensor* alphaConstantTensor = N_CHECK(alphaConstant->getOutput(0));
-        broadcastTensors(ctx, alphaConstantTensor, matmulTensor);
         nvinfer1::IElementWiseLayer* scaledMatmul = N_CHECK(
             ctx->network()->addElementWise(*alphaConstantTensor, *matmulTensor, nvinfer1::ElementWiseOperation::kPROD));
         matmulTensor = N_CHECK(scaledMatmul->getOutput(0));
@@ -2300,9 +2511,8 @@ DEFINE_BUILTIN_OP_IMPORTER(Gemm)
         if (beta != 1.f)
         {
             nvinfer1::IConstantLayer* betaConstant
-                = addConstantScalar(ctx, beta, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
+                = addConstantScalar(ctx, beta, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, getNbDims(biasTensor));
             nvinfer1::ITensor* betaConstantTensor = N_CHECK(betaConstant->getOutput(0));
-            broadcastTensors(ctx, betaConstantTensor, biasTensor);
             nvinfer1::IElementWiseLayer* scaledBias = N_CHECK(ctx->network()->addElementWise(
                 *betaConstantTensor, *biasTensor, nvinfer1::ElementWiseOperation::kPROD));
             biasTensor = N_CHECK(scaledBias->getOutput(0));
@@ -2331,27 +2541,25 @@ DEFINE_BUILTIN_OP_IMPORTER(GlobalLpPool)
     ONNXTRT_CHECK_NODE((inputType == DataType::kFLOAT || inputType == DataType::kHALF),
         "Only FLOAT and HALF are supported in GlobalLpPool. The current type = " + getTrtDtypeName(inputType) + ".",
         node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
-    nvinfer1::Dims dims = tensor.getDimensions();
+    int32_t const nbDims = getNbDims(&tensor);
 
     OnnxAttrs attrs{node, ctx};
     float p = static_cast<float>(attrs.get("p", 2));
 
     // Add constants for p and 1/p
-    nvinfer1::Dims scalarDims{dims.nbDims};
-    std::fill(scalarDims.d, scalarDims.d + scalarDims.nbDims, 1);
     nvinfer1::IConstantLayer* pLayer;
     nvinfer1::IConstantLayer* pInvLayer;
     if (inputType == DataType::kHALF)
     {
-        pLayer = addConstantScalar(
-            ctx, static_cast<half_float::half>(p), ::ONNX_NAMESPACE::TensorProto::FLOAT16, scalarDims);
+        pLayer
+            = addConstantScalar(ctx, static_cast<half_float::half>(p), ::ONNX_NAMESPACE::TensorProto::FLOAT16, nbDims);
         pInvLayer = addConstantScalar(
-            ctx, static_cast<half_float::half>(1.F / p), ::ONNX_NAMESPACE::TensorProto::FLOAT16, scalarDims);
+            ctx, static_cast<half_float::half>(1.F / p), ::ONNX_NAMESPACE::TensorProto::FLOAT16, nbDims);
     }
     else
     {
-        pLayer = addConstantScalar(ctx, p, ::ONNX_NAMESPACE::TensorProto::FLOAT, scalarDims);
-        pInvLayer = addConstantScalar(ctx, 1.F / p, ::ONNX_NAMESPACE::TensorProto::FLOAT, scalarDims);
+        pLayer = addConstantScalar(ctx, p, ::ONNX_NAMESPACE::TensorProto::FLOAT, nbDims);
+        pInvLayer = addConstantScalar(ctx, 1.F / p, ::ONNX_NAMESPACE::TensorProto::FLOAT, nbDims);
     }
 
     // firstPow = pow(x, p)
@@ -2383,87 +2591,10 @@ DEFINE_BUILTIN_OP_IMPORTER(GreaterOrEqual)
         /*greater*/ true);
 }
 
-// Support opset21 GroupNorm, where scale and bias is shape [C] instead of [G].
-NodeOutputs groupNorm21Helper(ImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node, size_t const nodeIdx,
-    std::vector<TensorOrWeights>& inputs)
-{
-    auto* input = &convertToTensor(inputs.at(0), ctx);
-    auto* scale = &convertToTensor(inputs.at(1), ctx);
-    auto* bias = &convertToTensor(inputs.at(2), ctx);
-
-    OnnxAttrs attrs(node, ctx);
-    float epsilon = attrs.get("epsilon", 1e-5f);
-    int32_t nbGroups = attrs.get("num_groups", 1);
-
-    auto nbDims = input->getDimensions().nbDims;
-    uint32_t axesMask{0};
-    std::vector<int32_t> unsqueezeAxes;
-
-    for (int32_t i = 0; i < nbDims; i++)
-    {
-        if (i == 1)
-        {
-            continue;
-        }
-        // Axes should correspond to the spatial dimensions
-        if (i >= 2)
-        {
-            axesMask |= 1 << i;
-        }
-        unsqueezeAxes.push_back(i);
-    }
-
-    // Reshape [N, C, ...] to [N, G, C/G, ...]
-    auto inShape = shapeOf(*input);
-
-    auto gnShape = concat(ctx, gather(ctx, inShape, shapeVector(0)), shapeVector(nbGroups));
-    gnShape = concat(ctx, gnShape, floorDiv(ctx, gather(ctx, inShape, shapeVector(1)), shapeVector(nbGroups)));
-    gnShape = concat(ctx, gnShape, shapeVector(-1));
-    auto gnReshaped = &reshape(ctx, *input, gnShape);
-
-    // Run instanceNorm with scale = 1, bias = 0
-
-    auto tmpScale
-        = constantOfShape(ctx, addConstantScalar(ctx, 1.0F, ::ONNX_NAMESPACE::TensorProto::FLOAT)->getOutput(0),
-            &gather(ctx, shapeOf(*gnReshaped), shapeVector(1)).tensor(ctx));
-    auto tmpBias
-        = constantOfShape(ctx, addConstantScalar(ctx, 0.0F, ::ONNX_NAMESPACE::TensorProto::FLOAT)->getOutput(0),
-            &gather(ctx, shapeOf(*gnReshaped), shapeVector(1)).tensor(ctx));
-
-    tmpScale = castHelper(ctx, tmpScale, scale->getType());
-    tmpBias = castHelper(ctx, tmpBias, bias->getType());
-
-    tmpScale = unsqueezeTensor(ctx, *tmpScale, unsqueezeAxes);
-    tmpBias = unsqueezeTensor(ctx, *tmpBias, unsqueezeAxes);
-
-    auto tmpNorm = N_CHECK(ctx->network()->addNormalization(*gnReshaped, *tmpScale, *tmpBias, axesMask));
-    tmpNorm->setEpsilon(epsilon);
-
-    auto normOut = N_CHECK(tmpNorm->getOutput(0));
-
-    // Reshape back to [N, C, ...]
-    auto reshapeBackOut = &reshape(ctx, *normOut, inShape);
-
-    // Do final scale and bias add.
-    using eOp = nvinfer1::ElementWiseOperation;
-    scale = unsqueezeTensor(ctx, *scale, unsqueezeAxes);
-    bias = unsqueezeTensor(ctx, *bias, unsqueezeAxes);
-    auto scaleLayer = N_CHECK(ctx->network()->addElementWise(*scale, *reshapeBackOut, eOp::kPROD));
-    auto scaledOutput = N_CHECK(scaleLayer->getOutput(0));
-    auto biasLayer = N_CHECK(ctx->network()->addElementWise(*scaledOutput, *bias, eOp::kSUM));
-    auto biasOutput = N_CHECK(biasLayer->getOutput(0));
-
-    return {{biasOutput}};
-}
-
 DEFINE_BUILTIN_OP_IMPORTER(GroupNormalization)
 {
-    if (ctx->getOpsetVersion() >= 21)
-    {
-        return groupNorm21Helper(ctx, node, nodeIdx, inputs);
-    }
-
-    return normalizationHelper(ctx, node, nodeIdx, inputs);
+    bool const useV2 = ctx->getOpsetVersion() >= 21;
+    return normalizationHelper(ctx, node, nodeIdx, inputs, useV2);
 }
 
 // singlePassShape is the shape of the output from a single pass.
@@ -2575,11 +2706,11 @@ DEFINE_BUILTIN_OP_IMPORTER(GRU)
 
     // Need to split weights/biases into ZR gates and H gate, because h(t) computations depend on z(t) and r(t).
     nvinfer1::ITensor* numDirectionsTensor
-        = addConstantScalar(ctx, numDirections, ::ONNX_NAMESPACE::TensorProto::INT32, Dims{1, {1}})->getOutput(0);
+        = addConstantScalar(ctx, numDirections, ::ONNX_NAMESPACE::TensorProto::INT32, 1)->getOutput(0);
     nvinfer1::ITensor* hiddenSizeTensor
-        = addConstantScalar(ctx, hiddenSize, ::ONNX_NAMESPACE::TensorProto::INT32, Dims{1, {1}})->getOutput(0);
+        = addConstantScalar(ctx, hiddenSize, ::ONNX_NAMESPACE::TensorProto::INT32, 1)->getOutput(0);
     nvinfer1::ITensor* hiddenSizeDoubledTensor
-        = addConstantScalar(ctx, 2 * hiddenSize, ::ONNX_NAMESPACE::TensorProto::INT32, Dims{1, {1}})->getOutput(0);
+        = addConstantScalar(ctx, 2 * hiddenSize, ::ONNX_NAMESPACE::TensorProto::INT32, 1)->getOutput(0);
     nvinfer1::ITensor* eDimTensor = getAxisLength(ctx, input, 2, Dims{1, {1}});
 
     nvinfer1::ITensor* weightsZRStart = addConstant(ctx, std::vector<int32_t>{0, 0, 0},
@@ -2655,13 +2786,11 @@ DEFINE_BUILTIN_OP_IMPORTER(GRU)
     auto const initialStateShape = [&ctx, &numDirections, &hiddenSize, &input, &net]() -> nvinfer1::ITensor* {
         // Get batchSize from input shape
         nvinfer1::ITensor* numDirectionsTensor
-            = addConstantScalar(ctx, numDirections, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, Dims{1, {1}})
-                  ->getOutput(0);
+            = addConstantScalar(ctx, numDirections, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, 1)->getOutput(0);
         LOG_VERBOSE("numDirections is: " << numDirections
                                          << ", numDirections Tensor shape: " << numDirectionsTensor->getDimensions());
         nvinfer1::ITensor* hiddenSizeTensor
-            = addConstantScalar(ctx, hiddenSize, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, Dims{1, {1}})
-                  ->getOutput(0);
+            = addConstantScalar(ctx, hiddenSize, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, 1)->getOutput(0);
         LOG_VERBOSE(
             "hiddenSize is: " << hiddenSize << ", hiddenSizeTensor shape: " << hiddenSizeTensor->getDimensions());
         nvinfer1::ITensor* batchSizeTensor = getAxisLength(ctx, input, 1, Dims{1, {1}});
@@ -2690,7 +2819,7 @@ DEFINE_BUILTIN_OP_IMPORTER(GRU)
             return &convertToTensor(inputs.at(inputIdx), ctx);
         }
         return constantOfShape(ctx,
-            addConstantScalar(ctx, 0.f, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, Dims{1, {1}})->getOutput(0),
+            addConstantScalar(ctx, 0.f, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1)->getOutput(0),
             gateOutputShape);
     };
 
@@ -2810,10 +2939,9 @@ DEFINE_BUILTIN_OP_IMPORTER(GRU)
     // H(t) = (1 - z(t)) . h(t) + (z(t) . H(t-1))
     // Constant `1` needs to be the same type as the inputs, either FP16 or FP32.
     auto* constOne = zt->getType() == nvinfer1::DataType::kHALF
-        ? N_CHECK(addConstantScalar(
-              ctx, static_cast<half_float::half>(1), ::ONNX_NAMESPACE::TensorProto::FLOAT16, Dims3{1, 1, 1})
+        ? N_CHECK(addConstantScalar(ctx, static_cast<half_float::half>(1), ::ONNX_NAMESPACE::TensorProto::FLOAT16, 3)
                       ->getOutput(0))
-        : N_CHECK(addConstantScalar(ctx, 1.f, ::ONNX_NAMESPACE::TensorProto::FLOAT, Dims3{1, 1, 1})->getOutput(0));
+        : N_CHECK(addConstantScalar(ctx, 1.f, ::ONNX_NAMESPACE::TensorProto::FLOAT, 3)->getOutput(0));
     nvinfer1::ITensor* Ht = getElementWiseResult(ctx,
         *getElementWiseResult(ctx, *getElementWiseResult(ctx, *constOne, *zt, eOp::kSUB), *ht, eOp::kPROD),
         *getElementWiseResult(ctx, *zt, *Ht1Output, eOp::kPROD), eOp::kSUM);
@@ -2890,14 +3018,14 @@ DEFINE_BUILTIN_OP_IMPORTER(HammingWindow)
 
     auto* cosOutput = windowHelper(ctx, 2.F * M_PI, window, N, nvinfer1::UnaryOperation::kCOS, periodic);
 
-    auto betaTensor = N_CHECK(addConstantScalar(ctx, beta, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
-        nvinfer1::Dims{1, {1}})->getOutput(0));
+    auto betaTensor
+        = N_CHECK(addConstantScalar(ctx, beta, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1)->getOutput(0));
     auto betaLayer
         = N_CHECK(ctx->network()->addElementWise(*betaTensor, *cosOutput, nvinfer1::ElementWiseOperation::kPROD));
     auto betaOutput = N_CHECK(betaLayer->getOutput(0));
 
-    auto alphaTensor = N_CHECK(addConstantScalar(ctx, alpha, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
-        nvinfer1::Dims{1, {1}})->getOutput(0));
+    auto alphaTensor
+        = N_CHECK(addConstantScalar(ctx, alpha, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1)->getOutput(0));
     auto alphaLayer
         = N_CHECK(ctx->network()->addElementWise(*alphaTensor, *betaOutput, nvinfer1::ElementWiseOperation::kSUB));
 
@@ -3018,7 +3146,8 @@ DEFINE_BUILTIN_OP_IMPORTER(If)
         NameScope nameScope(*ctx);
 
         std::vector<Status> errors{};
-        onnx2trt::parseGraph(ctx, body, errors);
+        onnx2trt::parseGraph(
+            ctx, body, errors, /*deserializingINetwork=*/false, /*currentNode=*/nullptr, /*subgraphParentIdx=*/nodeIdx);
         for (int32_t i = 0; i < nbOutputs; i++)
         {
             graphOutputs.emplace_back(ctx->tensors().at(body.output(i).name()));
@@ -3044,11 +3173,11 @@ DEFINE_BUILTIN_OP_IMPORTER(If)
     std::vector<TensorOrWeights> elseSubgraphTensors;
 
     ctx->localFunctionStack().push_back({"then_branch", thenGraph.name(), {}});
-    importSubgraph(ctx, thenGraph, thenLayers, thenSubgraphTensors);
+    importSubgraph(ctx, thenGraph, thenLayers, thenSubgraphTensors, /*subgraphParentIdx=*/nodeIdx);
     ctx->localFunctionStack().pop_back();
 
     ctx->localFunctionStack().push_back({"else_branch", elseGraph.name(), {}});
-    importSubgraph(ctx, elseGraph, elseLayers, elseSubgraphTensors);
+    importSubgraph(ctx, elseGraph, elseLayers, elseSubgraphTensors, /*subgraphParentIdx=*/nodeIdx);
     ctx->localFunctionStack().pop_back();
 
     using InputsMap = std::unordered_map<std::string, nvinfer1::IIfConditionalInputLayer*>;
@@ -3117,7 +3246,7 @@ DEFINE_BUILTIN_OP_IMPORTER(InstanceNormalization)
     uint32_t nativeInstanceNormFlag = 1U << static_cast<uint32_t>(nvonnxparser::OnnxParserFlag::kNATIVE_INSTANCENORM);
     if (flags & nativeInstanceNormFlag)
     {
-        return normalizationHelper(ctx, node, nodeIdx, inputs);
+        return normalizationHelper(ctx, node, nodeIdx, inputs, /*useV2*/ true);
     }
     ONNXTRT_CHECK_NODE((inputDataType == DataType::kFLOAT || inputDataType == DataType::kHALF),
         "Inputs to InstanceNorm plugin must be either FLOAT or FLOAT16. Input type is " + getTrtDtypeName(inputDataType)
@@ -3138,10 +3267,8 @@ DEFINE_BUILTIN_OP_IMPORTER(IsInf)
     }
 
     auto& input = convertToTensor(inputs.at(0), ctx);
-    auto inputDims = input.getDimensions();
-    nvinfer1::Dims scalarDims{inputDims.nbDims};
-    std::fill(scalarDims.d, scalarDims.d + scalarDims.nbDims, 1);
-    auto& zeroTensor = *addConstantScalar(ctx, 0.F, ::ONNX_NAMESPACE::TensorProto::FLOAT, scalarDims)->getOutput(0);
+    int32_t const nbDims = getNbDims(&input);
+    auto& zeroTensor = *addConstantScalar(ctx, 0.F, ::ONNX_NAMESPACE::TensorProto::FLOAT, nbDims)->getOutput(0);
 
     if (detectNegative)
     {
@@ -3184,26 +3311,61 @@ DEFINE_BUILTIN_OP_IMPORTER(LayerNormalization)
     auto* input = &convertToTensor(inputs.at(0), ctx);
 
     auto dt = input->getType();
-    nvinfer1::IConstantLayer* scaleLayer;
-    nvinfer1::IConstantLayer* biasLayer;
-    if (dt == DataType::kHALF)
+    int32_t nbDims = getNbDims(input);
+
+    nvinfer1::ITensor* scale{nullptr};
+    if (inputs.at(1).isNullTensor())
     {
-        scaleLayer = addConstantScalar(ctx, static_cast<half_float::half>(1), ::ONNX_NAMESPACE::TensorProto::FLOAT16);
-        biasLayer = addConstantScalar(ctx, static_cast<half_float::half>(0), ::ONNX_NAMESPACE::TensorProto::FLOAT16);
-    }
-    else if (dt == DataType::kBF16)
-    {
-        scaleLayer = addConstantScalar(ctx, static_cast<BFloat16>(1), ::ONNX_NAMESPACE::TensorProto::BFLOAT16);
-        biasLayer = addConstantScalar(ctx, static_cast<BFloat16>(0), ::ONNX_NAMESPACE::TensorProto::BFLOAT16);
+        if (dt == DataType::kHALF)
+        {
+            scale = addConstantScalar(
+                ctx, static_cast<half_float::half>(1), ::ONNX_NAMESPACE::TensorProto::FLOAT16, nbDims)
+                        ->getOutput(0);
+        }
+        else if (dt == DataType::kBF16)
+        {
+            scale = addConstantScalar(ctx, static_cast<BFloat16>(1), ::ONNX_NAMESPACE::TensorProto::BFLOAT16, nbDims)
+                        ->getOutput(0);
+        }
+        else
+        {
+            scale = addConstantScalar(ctx, static_cast<float>(1), ::ONNX_NAMESPACE::TensorProto::FLOAT, nbDims)
+                        ->getOutput(0);
+        }
     }
     else
     {
-        scaleLayer = addConstantScalar(ctx, static_cast<float>(1), ::ONNX_NAMESPACE::TensorProto::FLOAT);
-        biasLayer = addConstantScalar(ctx, static_cast<float>(0), ::ONNX_NAMESPACE::TensorProto::FLOAT);
+        scale = &convertToTensor(inputs.at(1), ctx);
+        broadcastTensors(ctx, input, scale);
     }
-    auto* scale = inputs.at(1).isNullTensor() ? N_CHECK(scaleLayer->getOutput(0)) : &convertToTensor(inputs.at(1), ctx);
-    auto* bias = (inputs.size() == 3 && !inputs.at(2).isNullTensor()) ? &convertToTensor(inputs.at(2), ctx)
-                                                                      : N_CHECK(biasLayer->getOutput(0));
+    N_CHECK(scale);
+
+    nvinfer1::ITensor* bias{nullptr};
+    if (inputs.size() < 3 || inputs.at(2).isNullTensor())
+    {
+        if (dt == DataType::kHALF)
+        {
+            bias = addConstantScalar(
+                ctx, static_cast<half_float::half>(0), ::ONNX_NAMESPACE::TensorProto::FLOAT16, nbDims)
+                       ->getOutput(0);
+        }
+        else if (dt == DataType::kBF16)
+        {
+            bias = addConstantScalar(ctx, static_cast<BFloat16>(0), ::ONNX_NAMESPACE::TensorProto::BFLOAT16, nbDims)
+                       ->getOutput(0);
+        }
+        else
+        {
+            bias = addConstantScalar(ctx, static_cast<float>(0), ::ONNX_NAMESPACE::TensorProto::FLOAT, nbDims)
+                       ->getOutput(0);
+        }
+    }
+    else
+    {
+        bias = &convertToTensor(inputs.at(2), ctx);
+        broadcastTensors(ctx, input, bias);
+    }
+    N_CHECK(bias);
 
     OnnxAttrs attrs(node, ctx);
     float epsilon = attrs.get("epsilon", 1e-5f);
@@ -3211,7 +3373,6 @@ DEFINE_BUILTIN_OP_IMPORTER(LayerNormalization)
     nvinfer1::DataType computeType = nvinfer1::DataType::kFLOAT;
     convertDtype(attrs.get<int32_t>("stash_type", 1), &computeType);
 
-    int32_t const nbDims = input->getDimensions().nbDims;
     convertAxis(axis, nbDims, node, nodeIdx);
     uint32_t axesMask{0};
 
@@ -3221,11 +3382,7 @@ DEFINE_BUILTIN_OP_IMPORTER(LayerNormalization)
         axesMask |= 1 << i;
     }
 
-    // Broadcast scale and bias to input size
-    broadcastTensors(ctx, input, scale);
-    broadcastTensors(ctx, input, bias);
-
-    auto* layer = N_CHECK(ctx->network()->addNormalization(*input, *scale, *bias, axesMask));
+    auto* layer = N_CHECK(ctx->network()->addNormalizationV2(*input, *scale, *bias, axesMask));
     layer->setEpsilon(epsilon);
     auto const stronglyTyped = ctx->isStronglyTyped();
     if (!stronglyTyped)
@@ -3337,7 +3494,8 @@ DEFINE_BUILTIN_OP_IMPORTER(Loop)
 
     // Loop body
     std::vector<Status> errors{};
-    onnx2trt::parseGraph(ctx, body, errors);
+    onnx2trt::parseGraph(
+        ctx, body, errors, /*deserializingINetwork=*/false, /*currentNode=*/nullptr, /*subgraphParentIdx=*/nodeIdx);
 
     if (cond)
     {
@@ -3476,13 +3634,11 @@ DEFINE_BUILTIN_OP_IMPORTER(LSTM)
     // Get a shape tensor containing: (numDirections, batchSize, hiddenSize)
     auto const initialStateShape = [&ctx, &numDirections, &hiddenSize, &input]() -> nvinfer1::ITensor* {
         // Get batchSize from input shape
-        nvinfer1::ITensor* numDirectionsTensor = addConstantScalar(
-            ctx, numDirections, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, nvinfer1::Dims{1, {1}})
-                                                     ->getOutput(0);
+        nvinfer1::ITensor* numDirectionsTensor
+            = addConstantScalar(ctx, numDirections, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, 1)->getOutput(0);
         LOG_VERBOSE("numDirectionsTensor shape: " << numDirectionsTensor->getDimensions());
         nvinfer1::ITensor* hiddenSizeTensor
-            = addConstantScalar(ctx, hiddenSize, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, nvinfer1::Dims{1, {1}})
-                  ->getOutput(0);
+            = addConstantScalar(ctx, hiddenSize, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, 1)->getOutput(0);
         LOG_VERBOSE("hiddenSizeTensor shape: " << hiddenSizeTensor->getDimensions());
         nvinfer1::ITensor* batchSizeTensor = getAxisLength(ctx, input, 1, nvinfer1::Dims{1, {1}});
         LOG_VERBOSE("batchSizeTensor shape: " << batchSizeTensor->getDimensions());
@@ -3503,22 +3659,18 @@ DEFINE_BUILTIN_OP_IMPORTER(LSTM)
         if (tensorType == "HALF")
         {
             return constantOfShape(ctx,
-                addConstantScalar(
-                    ctx, half_float::half(0.f), ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, nvinfer1::Dims{1, {1}})
+                addConstantScalar(ctx, half_float::half(0.f), ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT16, 1)
                     ->getOutput(0),
                 gateOutputShape);
         }
         if (tensorType == "BF16")
         {
             return constantOfShape(ctx,
-                addConstantScalar(
-                    ctx, BFloat16(0.f), ::ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16, nvinfer1::Dims{1, {1}})
-                    ->getOutput(0),
+                addConstantScalar(ctx, BFloat16(0.f), ::ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16, 1)->getOutput(0),
                 gateOutputShape);
         }
         return constantOfShape(ctx,
-            addConstantScalar(ctx, 0.f, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, nvinfer1::Dims{1, {1}})
-                ->getOutput(0),
+            addConstantScalar(ctx, 0.f, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1)->getOutput(0),
             gateOutputShape);
     };
 
@@ -3823,7 +3975,6 @@ DEFINE_BUILTIN_OP_IMPORTER(LpPool)
     getKernelParams(ctx, node, &kernelShape, &strides, &begPadding, &endPadding, paddingMode, excludePadding, nullptr,
         nullptr, ceilMode);
 
-    nvinfer1::Dims scalarDims = makeDims(nbDims, 1);
     float kernelSz{1.0F};
     for (int32_t i = 0; i < kernelShape.nbDims; i++)
     {
@@ -3834,11 +3985,11 @@ DEFINE_BUILTIN_OP_IMPORTER(LpPool)
     if (dt == DataType::kHALF)
     {
         kernelSzLayer = addConstantScalar(
-            ctx, static_cast<half_float::half>(kernelSz), ::ONNX_NAMESPACE::TensorProto::FLOAT16, scalarDims);
+            ctx, static_cast<half_float::half>(kernelSz), ::ONNX_NAMESPACE::TensorProto::FLOAT16, nbDims);
     }
     else
     {
-        kernelSzLayer = addConstantScalar(ctx, kernelSz, ::ONNX_NAMESPACE::TensorProto::FLOAT, scalarDims);
+        kernelSzLayer = addConstantScalar(ctx, kernelSz, ::ONNX_NAMESPACE::TensorProto::FLOAT, nbDims);
     }
 
     nvinfer1::ITensor* output{nullptr};
@@ -4026,10 +4177,8 @@ DEFINE_BUILTIN_OP_IMPORTER(MeanVarianceNormalization)
     auto* stdDev = N_CHECK(sqrtLayer->getOutput(0));
 
     // denominator: avoid division by zero
-    nvinfer1::Dims scalarShape{dims.nbDims};
-    std::fill(scalarShape.d, scalarShape.d + scalarShape.nbDims, 1);
     auto* epsilonTensor
-        = addConstantScalar(ctx, 1e-9f, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, scalarShape)->getOutput(0);
+        = addConstantScalar(ctx, 1e-9f, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, dims.nbDims)->getOutput(0);
     auto* addEpsLayer = N_CHECK(ctx->network()->addElementWise(*stdDev, *epsilonTensor, eOp::kSUM));
     ctx->registerLayer(addEpsLayer, node);
     stdDev = N_CHECK(addEpsLayer->getOutput(0));
@@ -4738,6 +4887,12 @@ DEFINE_BUILTIN_OP_IMPORTER(ReduceLogSumExp)
     std::vector<TensorOrWeights> expResult
         = unaryHelper(ctx, node, nodeIdx, inputs.at(0), nvinfer1::UnaryOperation::kEXP);
 
+    // Include the axes input if present to ensure reduction is performed correctly
+    if (inputs.size() >= 2)
+    {
+        expResult.push_back(inputs.at(1));
+    }
+
     return importReduceLogSum(ctx, node, nodeIdx, expResult);
 }
 DECLARE_BUILTIN_OP_IMPORTER(ReduceSumSquare);
@@ -4794,6 +4949,91 @@ DEFINE_BUILTIN_OP_IMPORTER(ReduceSumSquare)
 DEFINE_BUILTIN_OP_IMPORTER(Relu)
 {
     return activationHelper(ctx, node, nodeIdx, inputs, nvinfer1::ActivationType::kRELU);
+}
+
+DEFINE_BUILTIN_OP_IMPORTER(RMSNormalization)
+{
+    auto* input = &convertToTensor(inputs.at(0), ctx);
+    auto* scale = &convertToTensor(inputs.at(1), ctx);
+
+    int32_t const nbDims = getNbDims(input);
+
+    OnnxAttrs attrs(node, ctx);
+    float epsilon = attrs.get("epsilon", 1e-5f);
+    nvinfer1::DataType computeType = nvinfer1::DataType::kFLOAT;
+    convertDtype(attrs.get<int32_t>("stash_type", 1), &computeType);
+
+    // Cast input to computeType if necessary
+    nvinfer1::ITensor* compInput = input;
+    if (compInput->getType() != computeType)
+    {
+        compInput = castHelper(ctx, compInput, computeType);
+    }
+
+    // XSquared = Mul(X, X)
+    auto* sqLayer
+        = N_CHECK(ctx->network()->addElementWise(*compInput, *compInput, nvinfer1::ElementWiseOperation::kPROD));
+    ctx->registerLayer(sqLayer, node);
+    nvinfer1::ITensor* xSquared = N_CHECK(sqLayer->getOutput(0));
+
+    // XSquaredMean = ReduceMean<axes=[axis..rank-1]>(XSquared), keepdims=true
+    int32_t axis = attrs.get("axis", -1);
+    convertAxis(axis, nbDims, node, nodeIdx);
+
+    uint32_t axesMask{0};
+    for (int32_t i = axis; i < nbDims; ++i)
+    {
+        axesMask |= 1U << i;
+    }
+
+    auto* meanLayer
+        = N_CHECK(ctx->network()->addReduce(*xSquared, nvinfer1::ReduceOperation::kAVG, axesMask, /*keepdims=*/true));
+    ctx->registerLayer(meanLayer, node);
+    nvinfer1::ITensor* xSquaredMean = N_CHECK(meanLayer->getOutput(0));
+
+    // MeanSquareEpsilon = Add(XSquaredMean, epsilon)
+    nvinfer1::ITensor* epsTensor
+        = N_CHECK(addConstantScalar(ctx, static_cast<float>(epsilon), ::ONNX_NAMESPACE::TensorProto::FLOAT))
+              ->getOutput(0);
+    epsTensor = castHelper(ctx, epsTensor, computeType);
+
+    broadcastTensors(ctx, xSquaredMean, epsTensor);
+
+    auto* addLayer
+        = N_CHECK(ctx->network()->addElementWise(*xSquaredMean, *epsTensor, nvinfer1::ElementWiseOperation::kSUM));
+    ctx->registerLayer(addLayer, node);
+    nvinfer1::ITensor* meanSquareEps = N_CHECK(addLayer->getOutput(0));
+
+    // RMS = Sqrt(MeanSquareEpsilon)
+    auto* sqrtLayer = N_CHECK(ctx->network()->addUnary(*meanSquareEps, nvinfer1::UnaryOperation::kSQRT));
+    ctx->registerLayer(sqrtLayer, node);
+    nvinfer1::ITensor* rmsTensor = N_CHECK(sqrtLayer->getOutput(0));
+
+    // Normalized = Div(X, RMS)
+    auto* normLayer
+        = N_CHECK(ctx->network()->addElementWise(*compInput, *rmsTensor, nvinfer1::ElementWiseOperation::kDIV));
+    ctx->registerLayer(normLayer, node);
+    nvinfer1::ITensor* normalized = N_CHECK(normLayer->getOutput(0));
+
+    // Cast back to original type if needed
+    auto const originalType = input->getType();
+    if (normalized->getType() != originalType)
+    {
+        normalized = castHelper(ctx, normalized, originalType);
+    }
+
+    // Ensure scale matches output dtype
+    if (scale->getType() != normalized->getType())
+    {
+        scale = castHelper(ctx, scale, normalized->getType());
+    }
+
+    broadcastTensors(ctx, normalized, scale);
+    // Y = Mul(Normalized, Scale)
+    auto* yLayer
+        = N_CHECK(ctx->network()->addElementWise(*normalized, *scale, nvinfer1::ElementWiseOperation::kPROD));
+    ctx->registerLayer(yLayer, node);
+    RETURN_FIRST_OUTPUT(yLayer, node, nodeIdx);
 }
 
 DEFINE_BUILTIN_OP_IMPORTER(Sign)
@@ -5065,6 +5305,52 @@ DEFINE_BUILTIN_OP_IMPORTER(Resize)
     RETURN_FIRST_OUTPUT(layer, node, nodeIdx);
 }
 
+DEFINE_BUILTIN_OP_IMPORTER(RotaryEmbedding)
+{
+    OnnxAttrs attrs(node, ctx);
+    bool const interleaved = attrs.get<bool>("interleaved", false);
+    int32_t const rotaryEmbeddingDim = attrs.get<int32_t>("rotary_embedding_dim", 0);
+
+    nvinfer1::ITensor* input = &convertToTensor(inputs.at(0), ctx);
+    bool const inputIs3D = input->getDimensions().nbDims == 3;
+
+    if (inputIs3D) // (batchSize, sequenceLength, hiddenSize=numHeads * headSize)
+    {
+        ONNXTRT_CHECK_NODE(attrs.count("num_heads"), "num_heads attribute is required for 3D input tensors.", node, nodeIdx, ErrorCode::kINVALID_NODE);
+        int32_t const numHeads = attrs.get<int32_t>("num_heads");
+        int32_t const hiddenSize = input->getDimensions().d[2];
+        ONNXTRT_CHECK_NODE(hiddenSize % numHeads == 0, "hiddenSize must be divisible by num_heads.", node, nodeIdx, ErrorCode::kINVALID_NODE);
+        auto shuffleLayer = N_CHECK(ctx->network()->addShuffle(*input));
+        shuffleLayer->setReshapeDimensions(nvinfer1::Dims{4, {0, 0, numHeads, -1}}); // (batchSize, sequenceLength, numHeads, headSize)
+        shuffleLayer->setSecondTranspose(nvinfer1::Permutation{0, 2, 1, 3}); // (batchSize, numHeads, sequenceLength, headSize)
+        input = N_CHECK(shuffleLayer->getOutput(0));
+    }
+
+    nvinfer1::ITensor* cosCache = &convertToTensor(inputs.at(1), ctx);
+    nvinfer1::ITensor* sinCache = &convertToTensor(inputs.at(2), ctx);
+
+    auto layer = N_CHECK(ctx->network()->addRotaryEmbedding(*input, *cosCache, *sinCache, interleaved, rotaryEmbeddingDim));
+    ctx->registerLayer(layer, node);
+
+    if (inputs.size() > 3)
+    {
+        nvinfer1::ITensor* positionIds = &convertToTensor(inputs.at(3), ctx);
+        layer->setInput(3, *positionIds);
+    }
+
+    auto* output = N_CHECK(layer->getOutput(0));
+
+    if (inputIs3D) // Keep the output in the same shape as the input
+    {
+        auto shuffleLayer = N_CHECK(ctx->network()->addShuffle(*output));
+        shuffleLayer->setFirstTranspose(nvinfer1::Permutation{0, 2, 1, 3}); // (batchSize, sequenceLength, numHeads, headSize)
+        shuffleLayer->setReshapeDimensions(nvinfer1::Dims{3, {0, 0, -1}}); // (batchSize, sequenceLength, hiddenSize=numHeads * headSize)
+        output = N_CHECK(shuffleLayer->getOutput(0));
+    }
+
+    return {{output}};
+}
+
 
 DEFINE_BUILTIN_OP_IMPORTER(Reshape)
 {
@@ -5205,12 +5491,10 @@ DEFINE_BUILTIN_OP_IMPORTER(RNN)
     auto const initialStateShape = [&ctx, &numDirections, &hiddenSize, &input]() -> nvinfer1::ITensor* {
         // Get batchSize from input shape
         nvinfer1::ITensor* numDirectionsTensor = N_CHECK(
-            addConstantScalar(ctx, numDirections, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, nvinfer1::Dims{1, {1}})
-                ->getOutput(0));
+            addConstantScalar(ctx, numDirections, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, 1)->getOutput(0));
         LOG_VERBOSE("numDirectionsTensor shape: " << numDirectionsTensor->getDimensions());
         nvinfer1::ITensor* hiddenSizeTensor = N_CHECK(
-            addConstantScalar(ctx, hiddenSize, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, nvinfer1::Dims{1, {1}})
-                ->getOutput(0));
+            addConstantScalar(ctx, hiddenSize, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, 1)->getOutput(0));
         LOG_VERBOSE("hiddenSizeTensor shape: " << hiddenSizeTensor->getDimensions());
         nvinfer1::ITensor* batchSizeTensor = getAxisLength(ctx, input, 1, nvinfer1::Dims{1, {1}});
         LOG_VERBOSE("batchSizeTensor shape: " << batchSizeTensor->getDimensions());
@@ -5226,8 +5510,7 @@ DEFINE_BUILTIN_OP_IMPORTER(RNN)
             return &convertToTensor(inputs.at(inputIdx), ctx);
         }
         return constantOfShape(ctx,
-            N_CHECK(addConstantScalar(ctx, 0.f, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, nvinfer1::Dims{1, {1}})
-                        ->getOutput(0)),
+            N_CHECK(addConstantScalar(ctx, 0.f, ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, 1)->getOutput(0)),
             initialStateShape());
     };
 
@@ -5473,7 +5756,8 @@ DEFINE_BUILTIN_OP_IMPORTER(Scan)
 
     // Loop Body. This is handled by dispatching to other op converters.
     std::vector<Status> errors{};
-    onnx2trt::parseGraph(ctx, body, errors);
+    onnx2trt::parseGraph(
+        ctx, body, errors, /*deserializingINetwork=*/false, /*currentNode=*/nullptr, /*subgraphParentIdx=*/nodeIdx);
 
     // Set up recurrence outputs (first N body graph outputs).
     std::vector<TensorOrWeights> nodeOutputs{};
@@ -6260,6 +6544,61 @@ DEFINE_BUILTIN_OP_IMPORTER(Tanh)
     return activationHelper(ctx, node, nodeIdx, inputs, nvinfer1::ActivationType::kTANH);
 }
 
+DEFINE_BUILTIN_OP_IMPORTER(TensorScatter)
+{
+    OnnxAttrs attrs(node, ctx);
+
+    auto const cacheDims = inputs.at(0).shape().nbDims;
+    auto const updateDims = inputs.at(1).shape().nbDims;
+
+    // Check that past_cache and update inputs are 4D (batch_size, num_heads, sequence_length, head_size)
+    ONNXTRT_CHECK_NODE(cacheDims == 4, "The past_cache tensor is required to be 4D, got " << cacheDims << "D.", node,
+        nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+    ONNXTRT_CHECK_NODE(updateDims == 4, "The update tensor is required to be 4D, got " << updateDims << "D.", node,
+        nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+
+    // Convert inputs to tensors
+    nvinfer1::ITensor& cache = convertToTensor(inputs.at(0), ctx);
+    nvinfer1::ITensor& update = convertToTensor(inputs.at(1), ctx);
+
+    // Get the axis attribute
+    auto axis = attrs.get<int32_t>("axis", -2);
+    if (axis > 0)
+    {
+        axis -= cacheDims;
+    }
+    ONNXTRT_CHECK_NODE(
+        axis == -2, "Sequence dimension must be -2, got " << axis, node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+
+    // Get the mode attribute
+    auto const mode = attrs.get<std::string>("mode", "linear");
+    ONNXTRT_CHECK_NODE(mode == "linear", "Only linear mode is supported for now, got " << mode, node, nodeIdx,
+        ErrorCode::kUNSUPPORTED_NODE);
+
+    nvinfer1::KVCacheMode cacheMode = nvinfer1::KVCacheMode::kLINEAR;
+
+    // Handle optional write_indices input
+    nvinfer1::ITensor* writeIndices{nullptr};
+    if (inputs.size() == 3 && !inputs.at(2).isNullTensor())
+    {
+        writeIndices = castHelper(ctx, &convertToTensor(inputs.at(2), ctx), DataType::kINT32);
+    }
+    else
+    {
+        // Create default write_indices: [batch_size] filled with zeros
+        auto const cacheShape = shapeOf(cache);
+        auto const batchSize = gather(ctx, cacheShape, shapeVector(0));
+        writeIndices = constantOfShape(ctx,
+            N_CHECK(addConstantScalar(ctx, 0, ::ONNX_NAMESPACE::TensorProto_DataType_INT32, 1)->getOutput(0)),
+            &batchSize.tensor(ctx));
+    }
+
+    // Create KVCacheUpdate layer
+    auto* layer = N_CHECK(ctx->network()->addKVCacheUpdate(cache, update, *writeIndices, cacheMode));
+    ctx->registerLayer(layer, node);
+    RETURN_FIRST_OUTPUT(layer, node, nodeIdx);
+}
+
 DEFINE_BUILTIN_OP_IMPORTER(ThresholdedRelu)
 {
     OnnxAttrs attrs(node, ctx);
@@ -6430,7 +6769,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Trilu)
     }
 
     // For lower Trilus, use greaterOrEquals. For upper Trilus, use lessOrEquals
-    bool const greater = upper == 0 ? true : false;
+    bool const greater = upper == 0;
     std::vector<TensorOrWeights> greaterOrEqualResult = greaterLessOrEqual(ctx, node, nodeIdx, rows, cols, greater);
     auto* condition = &convertToTensor(greaterOrEqualResult.at(0), ctx);
     auto* result = N_CHECK(ctx->network()->addSelect(*condition, *data, *zero));
@@ -7542,6 +7881,7 @@ DEFINE_BUILTIN_OP_IMPORTER(TRT_AveragePool)
 {
     return importAveragePool(ctx, node, nodeIdx, inputs);
 }
+
 
 } // namespace
 

--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 
 from . import backend
 
-__version__ = "10.14.0"
+__version__ = "10.15.1"


### PR DESCRIPTION
For more details, see the [10.15 GA release notes](https://docs.nvidia.com/deeplearning/tensorrt/latest/getting-started/release-notes-10/10.15.1.html)

- Added support for `RotaryEmbedding`, `RMSNormalization` and `TensorScatter` for improved LLM model support
- Added more specialized quantization ops for models quantized through TensorRT ModelOptimizer.
- Added `kREPORT_CAPABILITY_DLA` flag to enable per-node validation when building DLA engines through TensorRT.
- Added `kENABLE_PLUGIN_OVERRIDE` flag to enable TensorRT plugin override for nodes that share names with user plugins.
- Improved error reporting for models with multiple subgraphs, such as `Loop` or `Scan` nodes.