### PR TITLE
Fix GroupNormalization with num_groups=1 to include channel axis in reduction

### DIFF
--- a/importerUtils.cpp
+++ b/importerUtils.cpp
@@ -1451,7 +1451,7 @@ nvinfer1::Dims makeDims(int32_t nbDims, int64_t val)
 }
 
 NodeOutputs normalizationHelper(ImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node, size_t const nodeIdx,
-    std::vector<TensorOrWeights>& inputs, bool const useV2)
+    std::vector<TensorOrWeights>& inputs, bool const useV2, bool const includeChannelAxis)
 {
     auto* input = &convertToTensor(inputs.at(0), ctx);
     auto* scale = &convertToTensor(inputs.at(1), ctx);
@@ -1483,6 +1483,11 @@ NodeOutputs normalizationHelper(ImporterContext* ctx, const ::ONNX_NAMESPACE::No
             axesMask |= 1 << i;
         }
         unsqueezeAxes.push_back(i);
+    }
+
+    if (includeChannelAxis && nbGroups == 1)
+    {
+        axesMask |= 1u << 1;
     }
 
     scale = unsqueezeTensor(ctx, *scale, unsqueezeAxes);

--- a/importerUtils.hpp
+++ b/importerUtils.hpp
@@ -271,9 +271,9 @@ std::unique_ptr<nvinfer1::IPluginV3> createPlugin(ImporterContext* ctx, ::ONNX_N
 // Helper function to return the identity of a TensorOrWeights
 TensorOrWeights identity(ImporterContext* ctx, TensorOrWeights input);
 
-// Helper function to create normalization layers for GroupNorm and InstanceNorm
+// Helper function to create normalization layers for GroupNorm and InstanceNorm.
 NodeOutputs normalizationHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, size_t const nodeIdx,
-    std::vector<TensorOrWeights>& inputs, bool const useV2);
+    std::vector<TensorOrWeights>& inputs, bool const useV2, bool const includeChannelAxis = false);
 
 // Given a list of axes in the range of [-rank, rank-1], where rank is the rank
 // of the corresponding data tensor, normalize to [0, rank-1].

--- a/onnxOpImporters.cpp
+++ b/onnxOpImporters.cpp
@@ -2649,7 +2649,7 @@ DEFINE_BUILTIN_OP_IMPORTER(GreaterOrEqual)
 DEFINE_BUILTIN_OP_IMPORTER(GroupNormalization)
 {
     bool const useV2 = ctx->getOpsetVersion() >= 21;
-    return normalizationHelper(ctx, node, nodeIdx, inputs, useV2);
+    return normalizationHelper(ctx, node, nodeIdx, inputs, useV2, /*includeChannelAxis=*/true);
 }
 
 // singlePassShape is the shape of the output from a single pass.

--- a/onnx_backend_test.py
+++ b/onnx_backend_test.py
@@ -158,6 +158,7 @@ backend_test.include(r'.*test_resize.*custom.*')
 backend_test.include(r'.*test_split.*custom.*')
 backend_test.include(r'.*test_instancenorm_.*_custom.*')
 backend_test.include(r'.*test_slice.*custom.*')
+backend_test.include(r'.*test_group_normalization_.*')
 
 
 # exclude unenabled ops get pulled in with wildcards


### PR DESCRIPTION
## Summary

ONNX GroupNormalization with num_groups equal to 1 was silently producing per channel instance normalization instead of the LayerNorm over CHW behavior that the ONNX spec and PyTorch group_norm define. The cause was that the importer built axesMask from spatial dimensions only and excluded the channel axis, so when INormalizationLayer ran with nbGroups equal to 1 there was no implicit reduction over channels and the result collapsed to per channel statistics. This patch adds the channel axis to axesMask in the nbGroups equal to 1 case while keeping the existing spatial only mask for nbGroups greater than 1 (where the runtime explicitly forbids axis 1 in axesMask) and for InstanceNormalization.

## Test plan

- [x] Built nvonnxparser locally against TensorRT 10.16.1.11 headers and swapped it into the pip wheel layout to validate against a real engine on RTX 4060
- [x] Reproducer from issue 4756 now matches PyTorch and ONNX Runtime within fp32 noise (max abs diff goes from 0.66 to about 1.2e-7)
- [x] Sweep over num_groups in {1, 2, 4, C} on 4D inputs, {1, 2, 3, C} on 5D inputs, all passing against PyTorch and ORT references
- [x] InstanceNormalization regression check passes
- [x] Enabled the ONNX backend test_group_normalization_* cases (num_groups equal to 2 with C equal to 4), which also exercises the proper multi group path

Fixes NVIDIA/TensorRT#4756
Signed-off-by: Samaresh Kumar Singh <ssam3003@gmail.com>