### PR TITLE
Fix `GridSample` always using `nearest` mode on opset 20+

### DIFF
--- a/onnxOpImporters.cpp
+++ b/onnxOpImporters.cpp
@@ -6005,19 +6005,25 @@ DEFINE_BUILTIN_OP_IMPORTER(GridSample)
         sampleMode = nvinfer1::SampleMode::kREFLECT;
     }
 
+    // Opset 20 renamed the interpolation modes: bilinear -> linear, bicubic -> cubic.
     auto mode = attrs.get<std::string>("mode", "bilinear");
     nvinfer1::InterpolationMode interpolationMode{nvinfer1::InterpolationMode::kNEAREST};
     if (mode == "nearest")
     {
         interpolationMode = nvinfer1::InterpolationMode::kNEAREST;
     }
-    else if (mode == "bilinear")
+    else if (mode == "bilinear" || mode == "linear")
     {
         interpolationMode = nvinfer1::InterpolationMode::kLINEAR;
     }
-    else if (mode == "bicubic")
+    else if (mode == "bicubic" || mode == "cubic")
     {
         interpolationMode = nvinfer1::InterpolationMode::kCUBIC;
+    }
+    else
+    {
+        ONNXTRT_CHECK_NODE(false, "Unsupported GridSample interpolation mode: " << mode, node, nodeIdx,
+            ErrorCode::kUNSUPPORTED_NODE_ATTR);
     }
 
     bool const alignCorners{attrs.get<int32_t>("align_corners", 0) == 1};


### PR DESCRIPTION
### Description

GridSample 20 [renamed](https://onnx.ai/onnx/operators/text_diff_GridSample_16_20.html) bilinear and bicubic to linear and cubic, respectively. This meant the checks for `bilinear` and `bicubic` don't match and it silently falls back to `nearest`. Reproduced with both TensorRT 11.1 and TensorRT-RTX 1.5.

This PR makes it accept both strings and aborts when it encounters an unknown string instead of using the wrong mode.

Fixes https://github.com/NVIDIA/TensorRT/issues/4646