### PR TITLE
TensorRT 11.2 GA release

### DIFF
--- a/AttentionHelpers.cpp
+++ b/AttentionHelpers.cpp
@@ -34,22 +34,20 @@ namespace onnx2trt
 //! \param qkvInput The input tensor. This can either be a 4D tensor (batchSize, numHeads, sequenceLength, headSize) or
 //!                 a 3D tensor (batchSize, sequenceLength, hiddenSize=numHeads*headSize). If it is a 3D tensor,
 //!                 permute and reshape to the 4D shape before returning. Otherwise, return the input tensor.
-//! \param attrs The ONNX node attributes.
 //! \param ctx The importer context.
-//! \param isQ True if the input tensor is the Q tensor, false if it is the K or V tensor.
+//! \param numHeadsValue The number of heads in the tensor.
+//! \param needsReshape True if the tensor is 3D and needs to be reshaped to 4D.
 //! \return nvinfer1::ITensor& The Q, K, or V tensor.
 //!
 nvinfer1::ITensor& reshapeQKVTensor(
-    TensorOrWeights& qkvInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const isQ, bool const needsReshape)
+    TensorOrWeights& qkvInput, ImporterContext* ctx, int64_t const numHeadsValue, bool const needsReshape)
 {
     if (needsReshape)
     {
         // qkvInput is a 3D tensor (batchSize, sequenceLength, hiddenSize=numHeads * headSize).
         // Get relevant dimensions.
-        int64_t const numHeadsValue
-            = isQ ? attrs.get<int64_t>("q_num_heads", 0) : attrs.get<int64_t>("kv_num_heads", 0);
         ONNXTRT_CHECK(numHeadsValue != 0,
-            "q_num_heads and kv_num_heads attributes are not specified, which are required for 3D Q/K/V tensors",
+            "Number of attention heads is not specified, which is required for 3D Q/K/V tensors.",
             ErrorCode::kINVALID_NODE);
         ShapeTensor numHeads = shapeVector(numHeadsValue);
 
@@ -102,7 +100,7 @@ nvinfer1::ITensor& scaleQKTensor(nvinfer1::ITensor& qkTensor, OnnxAttrs const& a
     // Use the tensor's actual rank so this works for both 4D padded BHND and 3D packed NHD tensors.
     int32_t const nbDims = qkTensor.getDimensions().nbDims;
 
-    if (attrs.count("scale"))
+    if (attrs.contains("scale"))
     {
         // Obtain the sqrt of scale as a constant (output of a constant layer).
         nvinfer1::IConstantLayer* constant = addConstantScalar(
@@ -132,19 +130,37 @@ nvinfer1::ITensor& scaleQKTensor(nvinfer1::ITensor& qkTensor, OnnxAttrs const& a
 nvinfer1::ITensor& convertToQTensor(
     TensorOrWeights& qInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape)
 {
-    return scaleQKTensor(reshapeQKVTensor(qInput, attrs, ctx, true /*isQ*/, needsReshape), attrs, ctx);
+    return convertToQTensor(qInput, attrs, ctx, attrs.get<int64_t>("q_num_heads", 0), needsReshape);
+}
+
+nvinfer1::ITensor& convertToQTensor(TensorOrWeights& qInput, OnnxAttrs const& attrs, ImporterContext* ctx,
+    int64_t const numHeads, bool const needsReshape)
+{
+    return scaleQKTensor(reshapeQKVTensor(qInput, ctx, numHeads, needsReshape), attrs, ctx);
 }
 
 nvinfer1::ITensor& convertToKTensor(
     TensorOrWeights& kInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape)
 {
-    return scaleQKTensor(reshapeQKVTensor(kInput, attrs, ctx, false /*isQ*/, needsReshape), attrs, ctx);
+    return convertToKTensor(kInput, attrs, ctx, attrs.get<int64_t>("kv_num_heads", 0), needsReshape);
+}
+
+nvinfer1::ITensor& convertToKTensor(TensorOrWeights& kInput, OnnxAttrs const& attrs, ImporterContext* ctx,
+    int64_t const numHeads, bool const needsReshape)
+{
+    return scaleQKTensor(reshapeQKVTensor(kInput, ctx, numHeads, needsReshape), attrs, ctx);
 }
 
 nvinfer1::ITensor& convertToVTensor(
     TensorOrWeights& vInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape)
 {
-    return reshapeQKVTensor(vInput, attrs, ctx, false /*isQ*/, needsReshape);
+    return convertToVTensor(vInput, ctx, attrs.get<int64_t>("kv_num_heads", 0), needsReshape);
+}
+
+nvinfer1::ITensor& convertToVTensor(
+    TensorOrWeights& vInput, ImporterContext* ctx, int64_t const numHeads, bool const needsReshape)
+{
+    return reshapeQKVTensor(vInput, ctx, numHeads, needsReshape);
 }
 
 nvinfer1::ITensor& convertToMaskTensor(TensorOrWeights& maskInput, ImporterContext* ctx)

--- a/AttentionHelpers.hpp
+++ b/AttentionHelpers.hpp
@@ -32,6 +32,22 @@ nvinfer1::ITensor& convertToQTensor(
     TensorOrWeights& qInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape = false);
 
 //!
+//! \brief Convert the input tensor to the Q tensor accepted by TensorRT with an explicit head count.
+//!
+//! This overload is used by operators that use a different attribute name than ONNX Attention for head count, while
+//! keeping the same scale handling as \p convertToQTensor.
+//!
+//! \param qInput The input tensor to convert.
+//! \param attrs The attributes of the source node.
+//! \param ctx The importer context.
+//! \param numHeads The query head count.
+//! \param needsReshape True if the input tensor needs to be reshaped to 4D, false otherwise.
+//! \return nvinfer1::ITensor& The converted Q tensor with shape (batchSize, numHeads, sequenceLength, headSize).
+//!
+nvinfer1::ITensor& convertToQTensor(TensorOrWeights& qInput, OnnxAttrs const& attrs, ImporterContext* ctx,
+    int64_t numHeads, bool const needsReshape = false);
+
+//!
 //! \brief Convert the input tensor to the K (key) tensor accepted by TensorRT.
 //!
 //! This is a wrapper over \p convertToTensor with the following additional transformations:
@@ -50,6 +66,22 @@ nvinfer1::ITensor& convertToKTensor(
     TensorOrWeights& kInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape = false);
 
 //!
+//! \brief Convert the input tensor to the K tensor accepted by TensorRT with an explicit head count.
+//!
+//! This overload is used by operators that use a different attribute name than ONNX Attention for head count, while
+//! keeping the same scale handling as \p convertToKTensor.
+//!
+//! \param kInput The input tensor to convert.
+//! \param attrs The attributes of the source node.
+//! \param ctx The importer context.
+//! \param numHeads The key head count.
+//! \param needsReshape True if the input tensor needs to be reshaped to 4D, false otherwise.
+//! \return nvinfer1::ITensor& The converted K tensor with shape (batchSize, numHeads, sequenceLength, headSize).
+//!
+nvinfer1::ITensor& convertToKTensor(TensorOrWeights& kInput, OnnxAttrs const& attrs, ImporterContext* ctx,
+    int64_t numHeads, bool const needsReshape = false);
+
+//!
 //! \brief Convert the input tensor to the V (value) tensor accepted by TensorRT.
 //!
 //! This is a wrapper over \p convertToTensor with the following additional transformation:
@@ -64,6 +96,20 @@ nvinfer1::ITensor& convertToKTensor(
 //!
 nvinfer1::ITensor& convertToVTensor(
     TensorOrWeights& vInput, OnnxAttrs const& attrs, ImporterContext* ctx, bool const needsReshape = false);
+
+//!
+//! \brief Convert the input tensor to the V tensor accepted by TensorRT with an explicit head count.
+//!
+//! This overload is used by operators that use a different attribute name than ONNX Attention for head count.
+//!
+//! \param vInput The input tensor to convert.
+//! \param ctx The importer context.
+//! \param numHeads The value head count.
+//! \param needsReshape True if the input tensor needs to be reshaped to 4D, false otherwise.
+//! \return nvinfer1::ITensor& The converted V tensor with shape (batchSize, numHeads, sequenceLength, headSize).
+//!
+nvinfer1::ITensor& convertToVTensor(
+    TensorOrWeights& vInput, ImporterContext* ctx, int64_t numHeads, bool const needsReshape = false);
 
 //!
 //! \brief Convert the input tensor to the mask tensor accepted by TensorRT.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.27)
 project(onnx2trt LANGUAGES CXX C)
 
 set(ONNX2TRT_ROOT ${PROJECT_SOURCE_DIR})
 # Set C++17 as standard for the whole project, as required by ONNX 1.16
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Enable compiler warnings
 if (CMAKE_COMPILER_IS_GNUCC)
@@ -28,8 +28,8 @@ add_definitions("-DSOURCE_LENGTH=${SOURCE_LENGTH}")
 # Version information
 #--------------------------------------------------
 set(ONNX2TRT_MAJOR 11)
-set(ONNX2TRT_MINOR 1)
-set(ONNX2TRT_PATCH 0)
+set(ONNX2TRT_MINOR 2)
+set(ONNX2TRT_PATCH 1)
 set(ONNX2TRT_VERSION "${ONNX2TRT_MAJOR}.${ONNX2TRT_MINOR}.${ONNX2TRT_PATCH}" CACHE STRING "ONNX2TRT version")
 
 #--------------------------------------------------

--- a/ConditionalHelpers.cpp
+++ b/ConditionalHelpers.cpp
@@ -174,7 +174,7 @@ void getSubgraphInputs(const std::vector<nvinfer1::ILayer*>& newLayers, Subgraph
                 {
                     continue;
                 }
-                if (tensors.count(tensor) == 0)
+                if (!tensors.contains(tensor))
                 {
                     externalInputs[l].insert(i);
                 }

--- a/ImporterContext.cpp
+++ b/ImporterContext.cpp
@@ -250,7 +250,7 @@ void ImporterContext::registerLayer(
         layer->setName(uniqueName.c_str());
         if (layer->getType() == nvinfer1::LayerType::kCONSTANT)
         {
-            if (basename != uniqueName && mConstantLayers.find(uniqueName) != mConstantLayers.end())
+            if (basename != uniqueName && mConstantLayers.contains(uniqueName))
             {
                 LOG_ERROR("Constant layer: " << uniqueName << " can be a duplicate of: " << basename);
                 assert(!"Internal error: duplicate constant layers for the same weights");

--- a/ImporterContext.hpp
+++ b/ImporterContext.hpp
@@ -258,7 +258,7 @@ public:
         {
             return mOpsets.begin()->second;
         }
-        else if (mOpsets.count(domain))
+        else if (mOpsets.contains(domain))
         {
             return mOpsets.at(domain);
         }
@@ -371,7 +371,7 @@ public:
     void addLayerOutputTensors(std::string name, std::vector<TensorOrWeights> const& outputs)
     {
         static std::unordered_set<std::string> duplicateNames;
-        if (mNodeNameToTensor.find(name) != mNodeNameToTensor.end())
+        if (mNodeNameToTensor.contains(name))
         {
             // Log once (only if insertion succeeded) for each unique name.
             auto result = duplicateNames.insert(name);

--- a/ModelImporter.cpp
+++ b/ModelImporter.cpp
@@ -72,7 +72,7 @@ void setStringMap(
     {
         std::string name = tensors.at(i);
         T dataName = data.at(i);
-        if (map.count(name) > 0)
+        if (map.contains(name))
         {
             ONNXTRT_CHECK(map[name] == dataName,
                 "The order of tensorRangeMin/Max in context misaligns with the order of the attribute "
@@ -218,7 +218,7 @@ void ModelImporter::reportSubgraphs()
         //     1. It is not directly connected to an unsupported input
         //     2. An error was not reported when attempting to parse the node.
         bool unsupportedInput = checkForInput(node);
-        bool unsuccessfulParse = errorNodes.count(nodeIdx);
+        bool unsuccessfulParse = errorNodes.contains(nodeIdx);
         if (!unsupportedInput && !unsuccessfulParse)
         {
             if (newSubGraph)
@@ -264,7 +264,7 @@ bool shouldImportAsPlugin(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto cons
     bool const pluginOverriding
         = ctx->getFlags() & (1U << static_cast<uint32_t>(nvonnxparser::OnnxParserFlag::kENABLE_PLUGIN_OVERRIDE));
     OnnxAttrs attrs(node, ctx);
-    bool const isPluginNode = attrs.count("plugin_namespace");
+    bool const isPluginNode = attrs.contains("plugin_namespace");
     return (pluginOverriding || isPluginNode) && isNodeInPluginRegistry(ctx, node);
 }
 } // anonymous namespace
@@ -292,7 +292,7 @@ void parseNodeStaticCheck(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto cons
         {
             checkerFunc = &it->second;
         }
-        else if (opImporters.count(nodeType))
+        else if (opImporters.contains(nodeType))
         {
             // Internal error: op has an importer but no checker
             std::string errorMsg = "No static checker was found for " + nodeType;
@@ -407,7 +407,7 @@ void parseNode(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, si
 
     if (!importFunc)
     {
-        if (opImporters.count(nodeType))
+        if (opImporters.contains(nodeType))
         {
             importFunc = &opImporters.at(nodeType);
         }
@@ -477,7 +477,7 @@ void parseNode(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, si
         auto outputsRangeMax = attrs.get<std::vector<float>>("trt_outputs_range_max", {});
         setStringMap<float>(ctx, outputsVec, outputsRangeMax, ctx->tensorRangeMaxes());
 
-        if (attrs.count("trt_layer_precision"))
+        if (attrs.contains("trt_layer_precision"))
         {
             std::vector<nvinfer1::DataType> layerPrecision{attrs.get<nvinfer1::DataType>("trt_layer_precision")};
             setStringMap<nvinfer1::DataType>(ctx, layerName, layerPrecision, ctx->layerPrecisions());
@@ -568,7 +568,7 @@ void collectSubgraphOuterScopeRefs(
     {
         for (auto const& input : node.input())
         {
-            if (!input.empty() && !localTensors.count(input))
+            if (!input.empty() && !localTensors.contains(input))
             {
                 outerRefs.insert(input);
             }
@@ -849,7 +849,7 @@ bool ModelImporter::supportsOperator(char const* op_name) const noexcept
 {
     ONNXTRT_TRY
     {
-        return _op_importers.count(op_name);
+        return _op_importers.contains(op_name);
     }
     ONNXTRT_CATCH_RECORD
 
@@ -1034,7 +1034,7 @@ void ModelImporter::importModel()
         // Set locations for all tensors
         for (auto const& tensor : ctx->tensorLocations())
         {
-            ONNXTRT_CHECK((tensors.count(tensor.first) > 0), "The tensor does not have an assigned location.",
+            ONNXTRT_CHECK((tensors.contains(tensor.first)), "The tensor does not have an assigned location.",
                 nvonnxparser::ErrorCode::kINVALID_GRAPH);
             tensors.at(tensor.first)->setLocation(tensor.second);
         }

--- a/ModelRefitter.cpp
+++ b/ModelRefitter.cpp
@@ -4,6 +4,7 @@
 
 #include "ModelRefitter.hpp"
 #include "ShapedWeights.hpp"
+#include "importerUtils.hpp"
 #include "onnxProtoUtils.hpp"
 #include "toposort.hpp"
 
@@ -47,9 +48,57 @@ std::unordered_set<std::string> ModelRefitter::getRefittableWeights()
     return std::unordered_set<std::string>{weightNames.begin(), weightNames.end()};
 }
 
+void ModelRefitter::notifyObserver(char const* trtName, nvonnxparser::RefitTransformKind kind, int32_t onnxDtype,
+    nvinfer1::DataType trtDtype, int64_t count, std::span<char const* const> sources, float epsilon,
+    std::span<std::byte const> fixedData) noexcept
+{
+    if (mObserver == nullptr)
+    {
+        return;
+    }
+    nvonnxparser::RefitRecord const record{
+        .trtName = trtName,
+        .kind = kind,
+        .onnxDtype = onnxDtype,
+        .trtDtype = trtDtype,
+        .count = count,
+        .nbSources = static_cast<int32_t>(sources.size()),
+        .sourceOnnxNames = sources.data(),
+        .epsilon = epsilon,
+        .fixedData = fixedData.empty() ? nullptr : static_cast<void const*>(fixedData.data()),
+        .fixedDataSize = fixedData.size(),
+    };
+    mObserver->onRefittableWeight(record);
+}
+
+namespace
+{
+//! Resolve the nvinfer1 dtype that corresponds to an ONNX TensorProto::DataType value. Falls back
+//! to kFLOAT for any dtype the parser does not yet map -- callers can still record the onnxDtype
+//! value verbatim and decide what to do downstream.
+[[nodiscard]] nvinfer1::DataType resolveTrtDtype(int32_t onnxDtype) noexcept
+{
+    nvinfer1::DataType trtDtype{nvinfer1::DataType::kFLOAT};
+    (void) convertDtype(onnxDtype, &trtDtype);
+    return trtDtype;
+}
+
+//! Wrap an opaque pointer + byte count in a typed std::span<std::byte const> so the
+//! span-based notifyObserver signature stays unchanged at the call sites for inline-bytes kinds
+//! (kCONSTANT_NODE, kCONSTANT_OF_SHAPE).
+[[nodiscard]] std::span<std::byte const> asByteSpan(void const* data, size_t size) noexcept
+{
+    if (data == nullptr || size == 0)
+    {
+        return {};
+    }
+    return {static_cast<std::byte const*>(data), size};
+}
+} // namespace
+
 template <typename T, typename TConvertFunc>
-size_t ModelRefitter::batchnormWeightRefitter(
-    ::ONNX_NAMESPACE::NodeProto const& node, std::vector<ShapedWeights>& inputs, TConvertFunc&& f)
+size_t ModelRefitter::batchnormWeightRefitter(::ONNX_NAMESPACE::NodeProto const& node,
+    std::vector<ShapedWeights>& inputs, int32_t sourceOnnxDtype, TConvertFunc&& f)
 {
     auto const& scale = inputs.at(0);
     auto const& bias = inputs.at(1);
@@ -95,16 +144,24 @@ size_t ModelRefitter::batchnormWeightRefitter(
         combinedBias.at<T>(i) = biasValues[i] - meanValues[i] * combinedScale.at<T>(i);
     }
     size_t successfullyRefittedWeights = 0;
-    if (mRefittableWeights.count(combinedScale.name))
+    char const* foldSources[4] = {inputs.at(0).name, inputs.at(1).name, inputs.at(2).name, inputs.at(3).name};
+    float const epsilonFloat = static_cast<float>(eps);
+    if (mRefittableWeights.contains(combinedScale.name))
     {
         mRefittableWeights.erase(combinedScale.name);
+        notifyObserver(combinedScale.name, nvonnxparser::RefitTransformKind::kBATCH_NORM_FOLD_SCALE, sourceOnnxDtype,
+            resolveTrtDtype(combinedScale.type), static_cast<int64_t>(combinedScale.count()),
+            std::span<char const* const>{foldSources}, epsilonFloat);
         ONNXTRT_CHECK(mRefitter->setNamedWeights(combinedScale.name, std::move(combinedScale)),
             "Failed to set named weights", ErrorCode::kREFIT_FAILED);
         ++successfullyRefittedWeights;
     }
-    if (mRefittableWeights.count(combinedBias.name))
+    if (mRefittableWeights.contains(combinedBias.name))
     {
         mRefittableWeights.erase(combinedBias.name);
+        notifyObserver(combinedBias.name, nvonnxparser::RefitTransformKind::kBATCH_NORM_FOLD_BIAS, sourceOnnxDtype,
+            resolveTrtDtype(combinedBias.type), static_cast<int64_t>(combinedBias.count()),
+            std::span<char const* const>{foldSources}, epsilonFloat);
         ONNXTRT_CHECK(mRefitter->setNamedWeights(combinedBias.name, std::move(combinedBias)),
             "Failed to set named weights", ErrorCode::kREFIT_FAILED);
         ++successfullyRefittedWeights;
@@ -160,6 +217,16 @@ void ModelRefitter::refitOnnxGraph(::ONNX_NAMESPACE::GraphProto const& graph)
         ShapedWeights weights;
         ONNXTRT_CHECK(mWeightsContext.convertOnnxWeights(initializer, &weights, /*ownAllWeights=*/true),
             "Failed to import initializer.", ErrorCode::kUNSUPPORTED_NODE);
+        if (mObserver != nullptr)
+        {
+            char const* const sourceName = initializer.name().c_str();
+            auto const transformKind = initializer.data_type() == ::ONNX_NAMESPACE::TensorProto::DOUBLE
+                ? nvonnxparser::RefitTransformKind::kDOUBLE_TO_FLOAT
+                : nvonnxparser::RefitTransformKind::kIDENTITY;
+            notifyObserver(initializer.name().c_str(), transformKind, initializer.data_type(),
+                resolveTrtDtype(weights.type), static_cast<int64_t>(weights.count()),
+                std::span<char const* const>{&sourceName, 1});
+        }
         ONNXTRT_CHECK(mRefitter->setNamedWeights(initializer.name().c_str(), std::move(weights)),
             "Failed to set named weights", ErrorCode::kREFIT_FAILED);
         ++mSuccessfullyRefittedWeights;
@@ -220,7 +287,7 @@ void ModelRefitter::refitOnnxConstantOfShapeNode(::ONNX_NAMESPACE::NodeProto con
         nvinfer1::Dims{1, {1}}, mTempRefittableWeights, mTempRefittableWeightsSuffixCounter, /*refittable=*/true);
     std::string name = namedConstantOfShape.getName();
 
-    if (!mRefittableWeights.count(name))
+    if (!mRefittableWeights.contains(name))
     {
         return;
     }
@@ -228,7 +295,7 @@ void ModelRefitter::refitOnnxConstantOfShapeNode(::ONNX_NAMESPACE::NodeProto con
     LOG_REFITTER_VERBOSE("Refitting ConstantOfShape node: " << node.name() << ", output: " << node.output(0));
 
     mRefittableWeights.erase(name);
-    if (mRefittedWeights.count(name))
+    if (mRefittedWeights.contains(name))
     {
         LOG_REFITTER_WARNING("Duplicate weight name name ("
             << name << ") was found when processing the graph (" << graphName
@@ -240,10 +307,12 @@ void ModelRefitter::refitOnnxConstantOfShapeNode(::ONNX_NAMESPACE::NodeProto con
     }
 
     ShapedWeights weights;
+    int32_t sourceOnnxDtype{::ONNX_NAMESPACE::TensorProto::FLOAT};
     if (node.attribute().size() == 1 && node.attribute(0).name() == "value")
     {
         ::ONNX_NAMESPACE::AttributeProto const& nodeAttribute = node.attribute(0);
         ::ONNX_NAMESPACE::TensorProto const& onnx_weights_tensor = nodeAttribute.t();
+        sourceOnnxDtype = onnx_weights_tensor.data_type();
         ONNXTRT_CHECK(mWeightsContext.convertOnnxWeights(onnx_weights_tensor, &weights),
             "Failed to import ConstantOfShape node.", ErrorCode::kUNSUPPORTED_NODE);
     }
@@ -253,6 +322,13 @@ void ModelRefitter::refitOnnxConstantOfShapeNode(::ONNX_NAMESPACE::NodeProto con
         static_cast<float*>(weights.values)[0] = 0.f;
     }
 
+    if (mObserver != nullptr)
+    {
+        char const* const sourceName = node.output(0).c_str();
+        notifyObserver(name.c_str(), nvonnxparser::RefitTransformKind::kCONSTANT_OF_SHAPE, sourceOnnxDtype,
+            resolveTrtDtype(weights.type), static_cast<int64_t>(weights.count()),
+            std::span<char const* const>{&sourceName, 1}, 0.0F, asByteSpan(weights.values, weights.size_bytes()));
+    }
     ONNXTRT_CHECK(mRefitter->setNamedWeights(name.c_str(), std::move(weights)), "Failed to set named weights",
         ErrorCode::kREFIT_FAILED);
     ++mSuccessfullyRefittedWeights;
@@ -280,6 +356,7 @@ void ModelRefitter::refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& nod
         mRefittedWeights.insert(node.output(0));
     }
     ShapedWeights weights;
+    int32_t sourceOnnxDtype{::ONNX_NAMESPACE::TensorProto::UNDEFINED};
     ::ONNX_NAMESPACE::AttributeProto const& nodeAttribute = node.attribute(0);
     if (nodeAttribute.name() == "value_float")
     {
@@ -287,6 +364,7 @@ void ModelRefitter::refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& nod
         float value = nodeAttribute.f();
         ONNXTRT_CHECK(weights.count() == 1, "Failed to import Constant node.", ErrorCode::kUNSUPPORTED_NODE);
         std::memcpy(weights.values, &value, sizeof(float));
+        sourceOnnxDtype = ::ONNX_NAMESPACE::TensorProto::FLOAT;
     }
     else if (nodeAttribute.name() == "value_floats")
     {
@@ -296,6 +374,7 @@ void ModelRefitter::refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& nod
         ONNXTRT_CHECK(
             weights.count() == values.size(), "Failed to import Constant node.", ErrorCode::kUNSUPPORTED_NODE);
         std::memcpy(weights.values, values.data(), weights.count() * sizeof(float));
+        sourceOnnxDtype = ::ONNX_NAMESPACE::TensorProto::FLOAT;
     }
     else if (nodeAttribute.name() == "value_int")
     {
@@ -303,6 +382,7 @@ void ModelRefitter::refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& nod
         int64_t value = nodeAttribute.i();
         ONNXTRT_CHECK(weights.count() == 1, "Failed to import Constant node.", ErrorCode::kUNSUPPORTED_NODE);
         std::memcpy(weights.values, &value, sizeof(int64_t));
+        sourceOnnxDtype = ::ONNX_NAMESPACE::TensorProto::INT64;
     }
     else if (nodeAttribute.name() == "value_ints")
     {
@@ -312,12 +392,21 @@ void ModelRefitter::refitOnnxConstantNode(::ONNX_NAMESPACE::NodeProto const& nod
         ONNXTRT_CHECK(
             weights.count() == values.size(), "Failed to import Constant node.", ErrorCode::kUNSUPPORTED_NODE);
         std::memcpy(weights.values, values.data(), weights.count() * sizeof(int64_t));
+        sourceOnnxDtype = ::ONNX_NAMESPACE::TensorProto::INT64;
     }
     else
     {
         ::ONNX_NAMESPACE::TensorProto const& onnx_weights_tensor = nodeAttribute.t();
+        sourceOnnxDtype = onnx_weights_tensor.data_type();
         ONNXTRT_CHECK(mWeightsContext.convertOnnxWeights(onnx_weights_tensor, &weights),
             "Failed to import Constant node.", ErrorCode::kUNSUPPORTED_NODE);
+    }
+    if (mObserver != nullptr)
+    {
+        char const* const sourceName = node.output(0).c_str();
+        notifyObserver(node.output(0).c_str(), nvonnxparser::RefitTransformKind::kCONSTANT_NODE, sourceOnnxDtype,
+            resolveTrtDtype(weights.type), static_cast<int64_t>(weights.count()),
+            std::span<char const* const>{&sourceName, 1}, 0.0F, asByteSpan(weights.values, weights.size_bytes()));
     }
     ONNXTRT_CHECK(mRefitter->setNamedWeights(node.output(0).c_str(), std::move(weights)), "Failed to set named weights",
         ErrorCode::kREFIT_FAILED);
@@ -335,12 +424,19 @@ void ModelRefitter::refitOnnxBatchNormNode(
     // The following looping construct is due to the fact that some tensors
     // might be shared among the BatchNorm's inputs
     std::vector<std::string> const inputNames(node.input().begin() + 1, node.input().end());
+    // Captured from the first BN input initializer; reported through IRefitterObserver so the
+    // consumer sees the source ONNX dtype before convertOnnxWeights' DOUBLE-to-FLOAT promotion.
+    int32_t sourceOnnxDtype{::ONNX_NAMESPACE::TensorProto::UNDEFINED};
     for (size_t inputIdx = 0; inputIdx < inputNames.size(); ++inputIdx)
     {
         for (::ONNX_NAMESPACE::TensorProto const& initializer : graph.initializer())
         {
             if (inputNames.at(inputIdx) == initializer.name())
             {
+                if (inputIdx == 0)
+                {
+                    sourceOnnxDtype = initializer.data_type();
+                }
                 ShapedWeights weights;
                 ONNXTRT_CHECK(mWeightsContext.convertOnnxWeights(initializer, &weights),
                     "Failed to import initializer " << initializer.name(), ErrorCode::kUNSUPPORTED_NODE);
@@ -364,18 +460,19 @@ void ModelRefitter::refitOnnxBatchNormNode(
         && scaleType == batchNormInputs.at(3).type;
     if (typesEqual && scaleType == ::ONNX_NAMESPACE::TensorProto::FLOAT16)
     {
-        batchnormRefittedWeights
-            = batchnormWeightRefitter<half_float::half>(node, batchNormInputs, QuickCast<half_float::half>());
+        batchnormRefittedWeights = batchnormWeightRefitter<half_float::half>(
+            node, batchNormInputs, sourceOnnxDtype, QuickCast<half_float::half>());
     }
     else if (typesEqual && scaleType == ::ONNX_NAMESPACE::TensorProto::BFLOAT16)
     {
-        batchnormRefittedWeights = batchnormWeightRefitter<BFloat16>(node, batchNormInputs, QuickCast<BFloat16>());
+        batchnormRefittedWeights
+            = batchnormWeightRefitter<BFloat16>(node, batchNormInputs, sourceOnnxDtype, QuickCast<BFloat16>());
     }
     else
     {
         // Do calculations in FP32, possibly promoting/demoting arithmetic types of some operands.
-        batchnormRefittedWeights = batchnormWeightRefitter<float>(
-            node, batchNormInputs, [this](ShapedWeights const& w) { return mWeightsContext.getFP32Values(w); });
+        batchnormRefittedWeights = batchnormWeightRefitter<float>(node, batchNormInputs, sourceOnnxDtype,
+            [this](ShapedWeights const& w) { return mWeightsContext.getFP32Values(w); });
     }
     mSuccessfullyRefittedWeights += batchnormRefittedWeights;
 }

--- a/ModelRefitter.hpp
+++ b/ModelRefitter.hpp
@@ -9,7 +9,9 @@
 #include "WeightsContext.hpp"
 #include "errorHelpers.hpp"
 #include <onnx/onnx-ml.pb.h>
+#include <cstddef>
 #include <set>
+#include <span>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -59,16 +61,38 @@ private:
     std::unordered_set<std::string> mRefittableWeights;
     std::unordered_set<std::string> mRefittedWeights;
 
+    //! Optional observer receiving one callback per refittable weight during refit. Owned externally.
+    nvonnxparser::IRefitterObserver* mObserver{nullptr};
+
     mutable std::vector<Status> mErrors;
 
     std::unordered_set<std::string> getRefittableWeights();
 
+    //! Emit one record to the attached observer, if any. No-op when no observer is set.
+    //! \param trtName Name of the TensorRT refittable engine weight.
+    //! \param kind Transform that produces the refit data from the sources.
+    //! \param onnxDtype ONNX TensorProto::DataType of the source data before any transformation
+    //!   (e.g. DOUBLE for a kDOUBLE_TO_FLOAT initializer).
+    //! \param trtDtype TensorRT data type of the post-transform refit data passed to the
+    //!   refitter.
+    //! \param count Element count of the emitted refit data.
+    //! \param sources Parser-owned ONNX source names. Valid only during the callback.
+    //! \param epsilon Epsilon used by kBATCH_NORM_FOLD_* transforms; ignored otherwise.
+    //! \param fixedData Parser-owned attribute payload for kCONSTANT_NODE / kCONSTANT_OF_SHAPE.
+    //!   Empty span for the other kinds. Valid only during the callback.
+    void notifyObserver(char const* trtName, nvonnxparser::RefitTransformKind kind, int32_t onnxDtype,
+        nvinfer1::DataType trtDtype, int64_t count, std::span<char const* const> sources,
+        float epsilon = 0.0F, std::span<std::byte const> fixedData = {}) noexcept;
+
     //! T is the working type.
     //! TConvertFunc is a functor for converting ShapedWeights to an array of type T.
     //! It should return a T*.
+    //! \p sourceOnnxDtype is the original ONNX TensorProto::DataType of the BN input initializers
+    //! (before any DOUBLE-to-FLOAT promotion), reported verbatim through IRefitterObserver so a
+    //! consumer can replay the fold from the source-dtype bytes.
     template <typename T, typename TConvertFunc>
-    size_t batchnormWeightRefitter(
-        ::ONNX_NAMESPACE::NodeProto const& node, std::vector<ShapedWeights>& inputs, TConvertFunc&& f);
+    size_t batchnormWeightRefitter(::ONNX_NAMESPACE::NodeProto const& node, std::vector<ShapedWeights>& inputs,
+        int32_t sourceOnnxDtype, TConvertFunc&& f);
 
     void refitOnnxWeights();
     void refitOnnxGraph(::ONNX_NAMESPACE::GraphProto const& graph);
@@ -118,6 +142,12 @@ public:
     bool loadInitializer(char const* name, void const* data, size_t size) noexcept override;
 
     bool refitModelProto() noexcept override;
+
+    //! Set or clear the optional refit observer. Ownership remains with the caller.
+    void setRefitObserver(nvonnxparser::IRefitterObserver* observer) noexcept override
+    {
+        mObserver = observer;
+    }
 };
 
 } // namespace onnx2trt

--- a/NvOnnxParser.h
+++ b/NvOnnxParser.h
@@ -16,7 +16,7 @@
 //!
 
 #define NV_ONNX_PARSER_MAJOR 0
-#define NV_ONNX_PARSER_MINOR 1
+#define NV_ONNX_PARSER_MINOR 2
 #define NV_ONNX_PARSER_PATCH 0
 
 static constexpr int32_t NV_ONNX_PARSER_VERSION
@@ -428,6 +428,126 @@ public:
 };
 
 //!
+//! \enum RefitTransformKind
+//!
+//! \brief Identifies how a refittable engine weight is produced from one or more ONNX initializers
+//!        or node attributes.
+//!
+//! Emitted by IParserRefitter through IRefitterObserver to describe how each refittable engine
+//! weight is sourced. A consumer can record these descriptions at build time and replay them at
+//! engine-load time to refit directly via nvinfer1::IRefitter::setNamedWeights, without invoking
+//! the ONNX parser again.
+//!
+enum class RefitTransformKind : int32_t
+{
+    //! Source is one ONNX initializer; refit data equals the initializer data verbatim.
+    kIDENTITY = 0,
+
+    //! Source is one ONNX initializer of DOUBLE type; refit data is the FLOAT cast.
+    kDOUBLE_TO_FLOAT = 1,
+
+    //! Source is the four scale/bias/mean/variance initializers of a BatchNormalization node.
+    //! Refit data is combinedScale[i] = scale[i] / sqrt(variance[i] + epsilon).
+    kBATCH_NORM_FOLD_SCALE = 2,
+
+    //! Source is the four scale/bias/mean/variance initializers of a BatchNormalization node.
+    //! Refit data is combinedBias[i] = bias[i] - mean[i] * combinedScale[i].
+    kBATCH_NORM_FOLD_BIAS = 3,
+
+    //! Source is the value attribute of a Constant node. The bytes are carried in
+    //! RefitRecord::fixedData since they are not available as a separate ONNX initializer.
+    kCONSTANT_NODE = 4,
+
+    //! Source is the value attribute of a ConstantOfShape node (defaulting to 0.0 if absent).
+    //! The bytes are carried in RefitRecord::fixedData.
+    kCONSTANT_OF_SHAPE = 5,
+};
+
+//! Specialization. See `nvonnxparser::EnumMax()` for details.
+template <>
+constexpr int32_t EnumMax<RefitTransformKind>() noexcept
+{
+    return 5;
+}
+
+//!
+//! \struct RefitRecord
+//!
+//! \brief One refittable-weight description emitted by IRefitterObserver.
+//!
+//! All pointers in this struct are owned by the parser and are valid only for the duration of the
+//! IRefitterObserver::onRefittableWeight() call. Implementations that need to retain string or
+//! buffer contents beyond the call must copy them.
+//!
+struct RefitRecord
+{
+    //! Name to pass to nvinfer1::IRefitter::setNamedWeights for this weight. Always non-null.
+    char const* trtName;
+
+    //! What transformation produces the refit data from the sources.
+    RefitTransformKind kind;
+
+    //! ONNX TensorProto::DataType of the source data **before** any transformation. For kIDENTITY
+    //! this matches the parser-produced weight's ONNX type. For kDOUBLE_TO_FLOAT this is DOUBLE
+    //! (the post-cast result type is given by \p trtDtype). For kBATCH_NORM_FOLD_* and the
+    //! kCONSTANT* kinds the source and result ONNX types coincide.
+    int32_t onnxDtype;
+
+    //! TensorRT data type of the post-transform refit data. Provided so consumers can call
+    //! nvinfer1::IRefitter::setNamedWeights directly without re-implementing the
+    //! ONNX-to-TRT dtype mapping.
+    nvinfer1::DataType trtDtype;
+
+    //! Element count of the refit data.
+    int64_t count;
+
+    //! Number of source ONNX names supplied below. At most 4.
+    int32_t nbSources;
+
+    //! Names of the source ONNX initializers (or output tensor names for Constant nodes).
+    //! Array of length nbSources; each entry is null-terminated. Owned by the parser.
+    char const* const* sourceOnnxNames;
+
+    //! For kBATCH_NORM_FOLD_SCALE / kBATCH_NORM_FOLD_BIAS: the epsilon used in the fold formula.
+    //! For other kinds: unspecified, do not consume.
+    float epsilon;
+
+    //! For kCONSTANT_NODE and kCONSTANT_OF_SHAPE: pointer to the build-time-resolved weight
+    //! bytes the parser would write into the engine. The data has element type \p onnxDtype and
+    //! \p count elements; total length is \p fixedDataSize bytes. The consumer should copy this
+    //! data so it can be replayed at refit time. For other kinds: nullptr.
+    void const* fixedData;
+
+    //! Length of \p fixedData in bytes, or 0 when \p fixedData is null.
+    size_t fixedDataSize;
+};
+
+//!
+//! \class IRefitterObserver
+//!
+//! \brief Observer interface invoked by IParserRefitter once per refittable engine weight.
+//!
+//! Attach via IParserRefitter::setRefitObserver. The intended use is to build a self-describing
+//! refit table at build time that can drive nvinfer1::IRefitter::setNamedWeights directly at
+//! engine-load time, eliminating the runtime dependency on the original ONNX model structure.
+//!
+class IRefitterObserver
+{
+public:
+    virtual ~IRefitterObserver() noexcept = default;
+
+    //!
+    //! \brief Called once per refittable engine weight as the parser identifies it.
+    //!
+    //! Invoked during IParserRefitter::refitModelProto, refitFromBytes, or refitFromFile, in the
+    //! parser's natural traversal order over the ONNX graph. Implementations must not call back
+    //! into the parser or refitter from this method, and must not retain pointers from \p record
+    //! beyond the call.
+    //!
+    virtual void onRefittableWeight(RefitRecord const& record) noexcept = 0;
+};
+
+//!
 //! \class IParserRefitter
 //!
 //! \brief An interface designed to refit weights from an ONNX model.
@@ -535,6 +655,17 @@ public:
     //! \see getNbErrors() getError() loadModelProto()
     //!
     virtual bool refitModelProto() noexcept = 0;
+
+    //!
+    //! \brief Attach an observer that receives one callback per refittable engine weight.
+    //!
+    //! May be called any time before refitModelProto / refitFromBytes / refitFromFile. Pass
+    //! nullptr to detach. The observer must outlive the refit call, or be detached before
+    //! destruction.
+    //!
+    //! \see IRefitterObserver
+    //!
+    virtual void setRefitObserver(IRefitterObserver* observer) noexcept = 0;
 };
 
 } // namespace nvonnxparser

--- a/OnnxAttrs.cpp
+++ b/OnnxAttrs.cpp
@@ -9,7 +9,7 @@
 
 bool isExternalAttribute(std::string const& key, onnx2trt::ImporterContext* ctx)
 {
-    return !key.empty() && !ctx->localFunctionStack().empty() && ctx->localFunctionStack().back().attrs.count(key);
+    return !key.empty() && !ctx->localFunctionStack().empty() && ctx->localFunctionStack().back().attrs.contains(key);
 }
 
 template <>

--- a/OnnxAttrs.hpp
+++ b/OnnxAttrs.hpp
@@ -29,9 +29,9 @@ public:
         }
     }
 
-    bool count(std::string const& key) const
+    [[nodiscard]] bool contains(std::string const& key) const
     {
-        return mAttrs.count(key);
+        return mAttrs.contains(key);
     }
 
     ::ONNX_NAMESPACE::AttributeProto const* at(std::string key) const
@@ -45,7 +45,7 @@ public:
 
     bool exists(std::string key) const
     {
-        return mAttrs.count(key) != 0;
+        return mAttrs.contains(key);
     }
 
     ::ONNX_NAMESPACE::AttributeProto::AttributeType type(std::string const& key) const

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For press and other inquiries, please contact Hector Marinez at hmarinez@nvidia.
 
 ## Supported TensorRT Versions
 
-Development on the this branch is for the latest version of [TensorRT 11.1](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
+Development on the this branch is for the latest version of [TensorRT 11.2](https://developer.nvidia.com/nvidia-tensorrt-download) with full-dimensions and dynamic shape support.
 
 For previous versions of TensorRT, refer to their respective branches.
 
@@ -28,8 +28,8 @@ Current supported ONNX operators are found in the [operator support matrix](docs
 
 ### Dependencies
 
- - [TensorRT 11.1](https://developer.nvidia.com/tensorrt)
- - [TensorRT 11.1 open source libraries](https://github.com/NVIDIA/TensorRT/)
+ - [TensorRT 11.2](https://developer.nvidia.com/tensorrt)
+ - [TensorRT 11.2 open source libraries](https://github.com/NVIDIA/TensorRT/)
  - [Protobuf >= 3.20.3 (Optional)](https://github.com/google/protobuf/releases)
 
 ### Building
@@ -82,7 +82,7 @@ Refer to the link or run `polygraphy run -h` for more information on CLI options
 
 Python bindings for the ONNX-TensorRT parser are packaged in the shipped `.whl` files.
 
-TensorRT 11.1 supports ONNX release 1.21.0. Install it with:
+TensorRT 11.2 supports ONNX release 1.21.0. Install it with:
 
     python3 -m pip install onnx==1.21.0
 

--- a/RNNHelpers.cpp
+++ b/RNNHelpers.cpp
@@ -164,8 +164,8 @@ nvinfer1::ITensor* getRaggedMask(ImporterContext* ctx, const ::ONNX_NAMESPACE::N
     nvinfer1::ITensor* seqMask;
     if (reverse)
     {
-        counter = getElementWiseResult(
-            ctx, *unsqueezeTensor(ctx, *maxLen, {0}), *counter, nvinfer1::ElementWiseOperation::kSUB);
+        counter = getElementWiseResult(ctx, *unsqueezeTensor(ctx, *maxLen, std::array{int32_t{0}}), *counter,
+            nvinfer1::ElementWiseOperation::kSUB);
         seqMask = getElementWiseResult(ctx, *seqLens, *counter, nvinfer1::ElementWiseOperation::kLESS);
         seqMask = getUnaryResult(ctx, *seqMask, nvinfer1::UnaryOperation::kNOT);
     }

--- a/WeightsContext.cpp
+++ b/WeightsContext.cpp
@@ -244,7 +244,7 @@ bool WeightsContext::convertOnnxWeights(
     //  1. User provided
     //  2. External weights
     //  3. Model weights
-    bool const userWeights = mExternalInits.count(initName);
+    bool const userWeights = mExternalInits.contains(initName);
 
     if (userWeights)
     {
@@ -578,7 +578,7 @@ bool WeightsContext::loadExternalInit(char const* name, void const* data, size_t
         return false;
     }
 
-    if (mExternalInits.count(name))
+    if (mExternalInits.contains(name))
     {
         LOG_WARNING("Initializer " << name << " was previously provided. Overwriting previous data.");
     }

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,12 @@
 
 # ONNX-TensorRT Changelog
 
+# TensorRT 11.2 GA Release - 2026-8-3
+For more details, see the 11.2 GA release notes.
+
+- Added `IRefitterObserver` class for better refitting of ONNX models.
+- Added support for the `DFT` operator and 5D `GridSample` operators.
+
 # TensorRT 11.1 GA Release - 2026-6-22
 For more details, see the 11.1 GA release notes.
 

--- a/docs/TRT_custom_ops.md
+++ b/docs/TRT_custom_ops.md
@@ -140,3 +140,66 @@ Custom op for KV cache updates with packed update support. Based on the TensorSc
 
 - `past_cache` must always be 4D `[B, H, N, D]`.
 - `update` must be 4D `[B, H, N, D]` for padded form or 3D `[T, H, D]` for packed form.
+
+## TRT_MoE
+
+Custom op for Mixture-of-Experts (MoE) feed-forward layers. Maps to TensorRT's `IMoELayer` via `INetworkDefinition::addMoE`. Supports gated linear units with optional SiLU activation (SwiGLU), optional per-expert biases, and optional quantization of the down-projection activations.
+
+### Attributes
+
+<dl>
+<dt><tt>activation_type - INT</tt></dt>
+<dd>Activation function applied between the gate and up projections. 0 = no activation (kNONE), 1 = SiLU (kSILU). Default is 0.</dd>
+<dt><tt>quantization_mode - INT</tt></dt>
+<dd>0 = no quantization, 1 = static quantization, 2 = dynamic double quantization (dynamic_dblq). When non-zero, <tt>quantization_dtype</tt> must also be specified. Default is 0.</dd>
+<dt><tt>quantization_dtype - INT</tt></dt>
+<dd>TensorRT <tt>DataType</tt> enum value for the down-projection activation quantization type (e.g., kFP8, kFP4). Required when <tt>quantization_mode</tt> is non-zero. Default is kFP8.</dd>
+<dt><tt>quantization_block_shape - LIST of INT (4 elements)</tt></dt>
+<dd>Block shape <tt>[d0, d1, d2, d3]</tt> for dynamic double quantization. Required when <tt>quantization_mode</tt> is 2.</dd>
+<dt><tt>dyn_q_output_scale_dtype - INT</tt></dt>
+<dd>TensorRT <tt>DataType</tt> enum value for the output scale tensor in dynamic double quantization. Required when <tt>quantization_mode</tt> is 2. Default is kFLOAT.</dd>
+<dt><tt>swiglu_limit - FLOAT</tt></dt>
+<dd>Clamp limit for the SwiGLU activation. Only consulted when any of the three <tt>swiglu_*</tt> attributes are present. Default is +∞ (no clamping).</dd>
+<dt><tt>swiglu_alpha - FLOAT</tt></dt>
+<dd>Alpha scale for the SwiGLU activation. Default is 1.0.</dd>
+<dt><tt>swiglu_beta - FLOAT</tt></dt>
+<dd>Beta offset for the SwiGLU activation. Default is 0.0.</dd>
+</dl>
+
+### Inputs (6-10)
+
+<dl>
+<dt><tt>hiddenStates</tt> (index 0) - FP32/FP16/BF16</dt>
+<dd>3D tensor of shape [batchSize, seqLen, hiddenSize]. Token embeddings to route through the MoE layer.</dd>
+<dt><tt>selectedExpertsForTokens</tt> (index 1) - INT32</dt>
+<dd>3D tensor of shape [batchSize, seqLen, topK]. Expert indices selected for each token.</dd>
+<dt><tt>scoresForSelectedExperts</tt> (index 2) - FP32/FP16/BF16</dt>
+<dd>3D tensor of shape [batchSize, seqLen, topK]. Routing weights for the selected experts.</dd>
+<dt><tt>fcGateWeights</tt> (index 3) - FP32/FP16/BF16</dt>
+<dd>3D tensor of shape [numExperts, hiddenSize, moeInterSize]. Gate projection weights.</dd>
+<dt><tt>fcUpWeights</tt> (index 4) - FP32/FP16/BF16 </dt>
+<dd>3D tensor of shape [numExperts, hiddenSize, moeInterSize]. Up projection weights.</dd>
+<dt><tt>fcDownWeights</tt> (index 5) - FP32/FP16/BF16</dt>
+<dd>3D tensor of shape [numExperts, moeInterSize, hiddenSize]. Down projection weights.</dd>
+<dt><tt>fcGateBiases</tt> (optional, index 6) - FP32/FP16/BF16</dt>
+<dd>Bias for the gate projection. Must be provided together with <tt>fcUpBiases</tt> and <tt>fcDownBiases</tt> — all three biases are required or none.</dd>
+<dt><tt>fcUpBiases</tt> (optional, index 7) - FP32/FP16/BF16</dt>
+<dd>Bias for the up projection. See <tt>fcGateBiases</tt>.</dd>
+<dt><tt>fcDownBiases</tt> (optional, index 8) - FP32/FP16/BF16</dt>
+<dd>Bias for the down projection. See <tt>fcGateBiases</tt>.</dd>
+<dt><tt>fcDownActivationScale</tt> (optional, index 9) - FP8/FP4</dt>
+<dd>Quantization scale for down-projection activations. Required when <tt>quantization_mode</tt> is non-zero.</dd>
+</dl>
+
+### Outputs
+
+<dl>
+<dt><tt>Y</tt></dt>
+<dd>3D tensor of shape [batchSize, seqLen, hiddenSize]. MoE layer output with the same shape and data type as <tt>hiddenStates</tt>.</dd>
+</dl>
+
+### Restrictions
+
+- Biases must be provided for all three projections (gate, up, down) or for none.
+- `fcDownActivationScale` (index 9) must be present when `quantization_mode` is non-zero; `quantization_dtype` must also be set in that case.
+- `quantization_block_shape` and `dyn_q_output_scale_dtype` are required only when `quantization_mode` is 2.

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -2,7 +2,7 @@
 
 # Supported ONNX Operators
 
-TensorRT 11.1 supports operators in the inclusive range of opset 9 to opset 24. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
+TensorRT 11.2 supports operators in the inclusive range of opset 9 to opset 24. Latest information of ONNX operators can be found [here](https://github.com/onnx/onnx/blob/main/docs/Operators.md). More details and limitations are documented in the chart below.
 
 TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOAT16, FP8, FP4, INT32, INT64, INT8, INT4, UINT8, and BOOL
 
@@ -56,7 +56,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | Cos                       | Y          | FP32, FP16, BF16 |
 | Cosh                      | Y          | FP32, FP16, BF16 |
 | CumSum                    | Y          | FP32, FP16, BF16 | `axis` must be a build-time constant                                                                                                     |
-| DFT                       | N          |
+| DFT                       | Y          | FP32, FP16, BF16 | Runs on a cuFFT-backed plugin so cuFFT must be available at runtime. Complex tensors use the packed-real `[..., 2]` layout, and the innermost dimension must be a static 1 (real) or 2 (complex). The transform axis must be `-2`. The opset 20 `axis` input must be a build-time constant scalar. `dft_length` is required for the onesided inverse (C2R) and unsupported otherwise. FP16 and BF16 require power-of-two signal lengths. |
 | DeformConv                | Y          | FP32, FP16 | `input` must have 1D or 2D spatial dimensions. `pads` for the beginning and end along each spatial axis must be the same
 | DepthToSpace              | Y          | FP32, FP16, BF16, INT32, INT64 |
 | DequantizeLinear          | Y          | INT8, FP8, FP4, INT4 | `x_zero_point` must be zero                                                                                    |
@@ -83,7 +83,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | GlobalMaxPool             | Y          | FP32, FP16, BF16 |
 | Greater                   | Y          | FP32, FP16, BF16, INT32, INT64 |
 | GreaterOrEqual            | Y          | FP32, FP16, BF16, INT32, INT64 |
-| GridSample                | Y          | FP32, FP16 | Input must be 4D input.
+| GridSample                | Y          | FP32, FP16, BF16 | Input must be 4D or 5D.
 | GroupNormalization        | Y          | FP32, FP16, BF16 |
 | GRU                       | Y          | FP32, FP16, BF16 | For bidirectional GRUs, activation functions must be the same for both the forward and reverse pass
 | HammingWindow             | Y          | FP32, FP16 |
@@ -166,7 +166,7 @@ TensorRT supports the following ONNX data types: DOUBLE, FLOAT32, FLOAT16, BFLOA
 | RoiAlign                  | Y          | FP32, FP16 |
 | RotaryEmbedding           | Y          | FP32, FP16, BF16 | `position_ids` must be INT64 |
 | Round                     | Y          | FP32, FP16, BF16 |
-| STFT                      | Y          | FP32 | `frame_step` and `window` must be an initializer. Input must be real-valued.
+| STFT                      | Y          | FP32, FP16, BF16 | `frame_step` and `window` must be an initializer. Input must be real-valued. |
 | ScaledTanh                | Y          | FP32, FP16, BF16 |
 | Scan                      | Y          | FP32, FP16, BF16|
 | Scatter                   | Y          | FP32, FP16, BF16, INT32, INT64 |

--- a/importerUtils.cpp
+++ b/importerUtils.cpp
@@ -7,10 +7,17 @@
 #include "Status.hpp"
 #include "bfloat16.hpp"
 #include "errorHelpers.hpp"
-#include <ctype.h>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cctype>
 #include <ostream>
+#include <ranges>
 #include <regex>
 #include <set>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
 namespace onnx2trt
 {
 
@@ -762,29 +769,29 @@ void getKernelParams(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& no
 {
     int32_t const nbSpatialDims = kernelSize->nbDims;
     OnnxAttrs attrs(node, ctx);
-    if (attrs.count("kernel_shape"))
+    if (attrs.contains("kernel_shape"))
     {
         auto const* onnxKernelSize = attrs.at("kernel_shape");
         setAttr(kernelSize, onnxKernelSize, nbSpatialDims, 1);
     }
-    if (attrs.count("strides"))
+    if (attrs.contains("strides"))
     {
         auto const* onnxStrides = attrs.at("strides");
         setAttr(strides, onnxStrides, nbSpatialDims, 1);
     }
-    if (dilations && attrs.count("dilations"))
+    if (dilations && attrs.contains("dilations"))
     {
         auto const* onnxDilations = attrs.at("dilations");
         setAttr(dilations, onnxDilations, nbSpatialDims, 1);
     }
-    if (attrs.count("count_include_pad"))
+    if (attrs.contains("count_include_pad"))
     {
         auto const* includePad = attrs.at("count_include_pad");
         int32_t val = includePad->i();
         val == 1 ? countExcludePadding = false : countExcludePadding = true;
     }
     // For ConvTranspose Layer
-    if (attrs.count("output_padding"))
+    if (attrs.contains("output_padding"))
     {
         auto const* onnxOutputPadding = attrs.at("output_padding");
         setAttr(outputPadding, onnxOutputPadding, nbSpatialDims, 0);
@@ -795,7 +802,7 @@ void getKernelParams(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& no
     auto onnxAutoPad = attrs.get("auto_pad", std::string("NOTSET"));
     if (onnxAutoPad != "SAME_LOWER" && onnxAutoPad != "SAME_UPPER")
     {
-        if (attrs.count("pads"))
+        if (attrs.contains("pads"))
         {
             auto onnxPadding = attrs.get<std::vector<int32_t>>("pads");
             int32_t ndim = onnxPadding.size() / 2;
@@ -822,7 +829,7 @@ void getKernelParams(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& no
     {
         // If auto_pad is SAME_LOWER or SAME_UPPER, input padding should be calculated
         // "pads" attribute should not be specified
-        ONNXTRT_CHECK(!attrs.count("pads"),
+        ONNXTRT_CHECK(!attrs.contains("pads"),
             "Pads attribute should not be specified with SAME_LOWER or SAME_UPPER auto padding!",
             ErrorCode::kINVALID_NODE);
         // Note: ONNX is always NCHW ordering
@@ -884,7 +891,6 @@ nvinfer1::IPluginCreatorInterface* importPluginCreator(ImporterContext* ctx, std
 {
     nvinfer1::IPluginCreatorInterface* creator = nullptr;
 
-    int32_t numCreators = 0;
     std::vector<nvinfer1::IPluginCreatorInterface*> creators;
 
     int32_t numStdCreators = 0;
@@ -895,60 +901,41 @@ nvinfer1::IPluginCreatorInterface* importPluginCreator(ImporterContext* ctx, std
         creators.insert(creators.end(), stdCreators, stdCreators + numStdCreators);
     }
 
-    numCreators = creators.size();
     // Helper function to check if a plugin creator matches the requested plugin parameters
     auto matchesPlugin = [&](char const* name, char const* version, char const* ns) -> bool {
-        return std::string(name) == pluginName && std::string(version) == pluginVersion
-            && std::string(ns) == pluginNamespace;
+        return pluginName == name && pluginVersion == version && pluginNamespace == ns;
+    };
+    auto matchesPluginCreator = [&](auto const& pluginCreator) {
+        return matchesPlugin(
+            pluginCreator.getPluginName(), pluginCreator.getPluginVersion(), pluginCreator.getPluginNamespace());
     };
 
     // Search for a creator that matches the requested plugin
     // the creators are guaranteed to be unique
-    for (int32_t i = 0; i < numCreators; i++)
-    {
-        auto currentCreator = creators[i];
+    auto const it = std::find_if(creators.begin(), creators.end(), [&](auto* const currentCreator) -> bool {
         if (!currentCreator)
         {
-            continue;
+            return false;
         }
 
         // Get the creator version to determine the appropriate type
-        auto const creatorVersion = getPluginCreatorVersion(currentCreator);
-        bool matches = false;
-
-        switch (creatorVersion)
+        switch (getPluginCreatorVersion(currentCreator))
         {
         case CreatorVersion::kV1:
-        {
-            auto const v1Creator = static_cast<nvinfer1::IPluginCreator const*>(currentCreator);
-            matches = matchesPlugin(
-                v1Creator->getPluginName(), v1Creator->getPluginVersion(), v1Creator->getPluginNamespace());
-            break;
-        }
+            return matchesPluginCreator(static_cast<nvinfer1::IPluginCreator const&>(*currentCreator));
         case CreatorVersion::kV3ONE:
-        {
-            auto const v3Creator = static_cast<nvinfer1::IPluginCreatorV3One const*>(currentCreator);
-            matches = matchesPlugin(
-                v3Creator->getPluginName(), v3Creator->getPluginVersion(), v3Creator->getPluginNamespace());
-            break;
-        }
+            return matchesPluginCreator(static_cast<nvinfer1::IPluginCreatorV3One const&>(*currentCreator));
         case CreatorVersion::kV3QUICK:
-        {
-            auto const v3QuickCreator = static_cast<nvinfer1::IPluginCreatorV3Quick const*>(currentCreator);
-            matches = matchesPlugin(v3QuickCreator->getPluginName(), v3QuickCreator->getPluginVersion(),
-                v3QuickCreator->getPluginNamespace());
-            break;
-        }
+            return matchesPluginCreator(static_cast<nvinfer1::IPluginCreatorV3Quick const&>(*currentCreator));
        // No default case as the creatorVersion is guaranteed to be one of the above as per
        // `getPluginCreatorVersion()`. For any future plugin creator versions added, this switch statement will
        // need to be updated along with `getPluginCreatorVersion()`.
         }
-
-        if (matches)
-        {
-            creator = currentCreator;
-            break;
-        }
+        return false;
+    });
+    if (it != creators.end())
+    {
+        creator = *it;
     }
 
 
@@ -1040,7 +1027,7 @@ std::unique_ptr<nvinfer1::IPluginV3> createPlugin(ImporterContext* ctx, ::ONNX_N
         nvinfer1::QuickPluginCreationRequest request;
 
         // Node-level specifications override network-level preferences
-        if (attrs.count("aot"))
+        if (attrs.contains("aot"))
         {
             auto const aotOrJit = static_cast<bool>(attrs.get<int>("aot", 0));
             if (aotOrJit)
@@ -1186,7 +1173,7 @@ NodeOutputs modulatedDeformableConvPluginHelper(ImporterContext* ctx, ::ONNX_NAM
     // Parse attributes
     OnnxAttrs attrs(node, ctx);
     int32_t nbSpatialDims = nbDims - 2;
-    if (attrs.count("kernel_shape"))
+    if (attrs.contains("kernel_shape"))
     {
         ONNXTRT_CHECK(nbSpatialDims == attrs.at("kernel_shape")->ints().size(),
             "The attribute kernel_shape misaligns with the shape of the weight tensor.", ErrorCode::kUNSUPPORTED_NODE);
@@ -1196,14 +1183,14 @@ NodeOutputs modulatedDeformableConvPluginHelper(ImporterContext* ctx, ::ONNX_NAM
     }
 
     nvinfer1::Dims dilations = makeDims(nbSpatialDims, /*Default value of dilations*/ 1);
-    if (attrs.count("dilations"))
+    if (attrs.contains("dilations"))
     {
         auto const* onnxDilations = attrs.at("dilations");
         setAttr(&dilations, onnxDilations, nbSpatialDims, 1);
     }
 
     nvinfer1::Dims kernelShape = makeDims(nbSpatialDims, 0);
-    if (attrs.count("kernel_shape"))
+    if (attrs.contains("kernel_shape"))
     {
         auto const* onnxKernelShape = attrs.at("kernel_shape");
         setAttr(&kernelShape, onnxKernelShape, nbSpatialDims, 0);
@@ -1220,7 +1207,7 @@ NodeOutputs modulatedDeformableConvPluginHelper(ImporterContext* ctx, ::ONNX_NAM
     nvinfer1::Dims begPadding = makeDims(nbSpatialDims, /*Default value of pads*/ 0);
     nvinfer1::Dims endPadding = makeDims(nbSpatialDims, /*Default value of pads*/ 0);
 
-    if (attrs.count("pads"))
+    if (attrs.contains("pads"))
     {
         auto onnxPadding = attrs.get<std::vector<int32_t>>("pads");
         int32_t ndim = onnxPadding.size() / 2;
@@ -1240,7 +1227,7 @@ NodeOutputs modulatedDeformableConvPluginHelper(ImporterContext* ctx, ::ONNX_NAM
         ErrorCode::kUNSUPPORTED_NODE);
 
     nvinfer1::Dims strides = makeDims(nbSpatialDims, /*Default value of strides*/ 1);
-    if (attrs.count("strides"))
+    if (attrs.contains("strides"))
     {
         auto const* onnxStrides = attrs.at("strides");
         setAttr(&strides, onnxStrides, nbSpatialDims, 1);
@@ -1627,7 +1614,214 @@ bool IsReduceNoOp(
     ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, std::vector<TensorOrWeights> const& inputs)
 {
     OnnxAttrs attrs(node, ctx);
-    return (attrs.get("noop_with_empty_axes", 0) == 1) && (!attrs.count("axes")) && (inputs.size() == 1);
+    return (attrs.get("noop_with_empty_axes", 0) == 1) && (!attrs.contains("axes")) && (inputs.size() == 1);
+}
+
+namespace
+{
+
+//! \return true if weights were recovered from a Constant node. A scalar constant (nbDims == 0)
+//! is accepted; only the default-constructed sentinel (nbDims == -1) is unresolved.
+[[nodiscard]] bool resolvedWeights(ShapedWeights const& weights)
+{
+    return weights.shape.nbDims >= 0;
+}
+
+template <typename TargetType, typename SourceType>
+[[nodiscard]] bool valueFitsCast(SourceType value)
+{
+    if constexpr (std::is_same_v<TargetType, bool> || !std::is_integral_v<TargetType>)
+    {
+        return true;
+    }
+    else
+    {
+        auto const valueAsLongDouble = static_cast<long double>(value);
+        return std::isfinite(valueAsLongDouble)
+            && valueAsLongDouble >= static_cast<long double>(std::numeric_limits<TargetType>::lowest())
+            && valueAsLongDouble <= static_cast<long double>(std::numeric_limits<TargetType>::max());
+    }
+}
+
+template <typename TargetType, typename SourceType>
+[[nodiscard]] bool castWeightValues(ShapedWeights const& sourceWeights, ShapedWeights& targetWeights)
+{
+    size_t const count = sourceWeights.count();
+    if (count == 0)
+    {
+        return true;
+    }
+    if (sourceWeights.values == nullptr || targetWeights.values == nullptr)
+    {
+        return false;
+    }
+
+    auto const* sourceValues = static_cast<SourceType const*>(sourceWeights.values);
+    auto* targetValues = static_cast<TargetType*>(targetWeights.values);
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (!valueFitsCast<TargetType>(sourceValues[i]))
+        {
+            return false;
+        }
+        targetValues[i] = static_cast<TargetType>(sourceValues[i]);
+    }
+    return true;
+}
+
+//! Cast weights element-wise to TargetType. Source-type coverage is intentionally limited to
+//! the types a constant axes chain can carry (BOOL, INT8, UINT8, INT32, INT64, FLOAT).
+//! \return false for unsupported source types; callers must treat that as "do not fold".
+template <typename TargetType>
+[[nodiscard]] bool castWeightsToType(ShapedWeights const& sourceWeights, ShapedWeights& targetWeights)
+{
+    switch (sourceWeights.type)
+    {
+    case ::ONNX_NAMESPACE::TensorProto::BOOL: return castWeightValues<TargetType, bool>(sourceWeights, targetWeights);
+    case ::ONNX_NAMESPACE::TensorProto::INT8: return castWeightValues<TargetType, int8_t>(sourceWeights, targetWeights);
+    case ::ONNX_NAMESPACE::TensorProto::UINT8:
+        return castWeightValues<TargetType, uint8_t>(sourceWeights, targetWeights);
+    case ::ONNX_NAMESPACE::TensorProto::INT32:
+        return castWeightValues<TargetType, int32_t>(sourceWeights, targetWeights);
+    case ::ONNX_NAMESPACE::TensorProto::INT64:
+        return castWeightValues<TargetType, int64_t>(sourceWeights, targetWeights);
+    case ::ONNX_NAMESPACE::TensorProto::FLOAT:
+        return castWeightValues<TargetType, float>(sourceWeights, targetWeights);
+    default: return false;
+    }
+}
+
+[[nodiscard]] ShapedWeights castConstantWeights(
+    ImporterContext* ctx, ShapedWeights const& sourceWeights, nvinfer1::DataType const targetType)
+{
+    ShapedWeights::DataType targetOnnxType{};
+    bool success{false};
+    switch (targetType)
+    {
+    case nvinfer1::DataType::kBOOL:
+        targetOnnxType = ::ONNX_NAMESPACE::TensorProto::BOOL;
+        break;
+    case nvinfer1::DataType::kINT8:
+        targetOnnxType = ::ONNX_NAMESPACE::TensorProto::INT8;
+        break;
+    case nvinfer1::DataType::kUINT8:
+        targetOnnxType = ::ONNX_NAMESPACE::TensorProto::UINT8;
+        break;
+    case nvinfer1::DataType::kINT32:
+        targetOnnxType = ::ONNX_NAMESPACE::TensorProto::INT32;
+        break;
+    case nvinfer1::DataType::kINT64:
+        targetOnnxType = ::ONNX_NAMESPACE::TensorProto::INT64;
+        break;
+    case nvinfer1::DataType::kFLOAT:
+        targetOnnxType = ::ONNX_NAMESPACE::TensorProto::FLOAT;
+        break;
+    default: return ShapedWeights{};
+    }
+
+    ShapedWeights targetWeights = ctx->getWeightsContext().createTempWeights(targetOnnxType, sourceWeights.shape);
+    switch (targetOnnxType)
+    {
+    case ::ONNX_NAMESPACE::TensorProto::BOOL:
+        success = castWeightsToType<bool>(sourceWeights, targetWeights);
+        break;
+    case ::ONNX_NAMESPACE::TensorProto::INT8:
+        success = castWeightsToType<int8_t>(sourceWeights, targetWeights);
+        break;
+    case ::ONNX_NAMESPACE::TensorProto::UINT8:
+        success = castWeightsToType<uint8_t>(sourceWeights, targetWeights);
+        break;
+    case ::ONNX_NAMESPACE::TensorProto::INT32:
+        success = castWeightsToType<int32_t>(sourceWeights, targetWeights);
+        break;
+    case ::ONNX_NAMESPACE::TensorProto::INT64:
+        success = castWeightsToType<int64_t>(sourceWeights, targetWeights);
+        break;
+    case ::ONNX_NAMESPACE::TensorProto::FLOAT:
+        success = castWeightsToType<float>(sourceWeights, targetWeights);
+        break;
+    default: break;
+    }
+    return success ? targetWeights : ShapedWeights{};
+}
+
+void weightsToAxesVector(TensorOrWeights weights, std::vector<int32_t>* axes, ::ONNX_NAMESPACE::NodeProto const& node,
+    size_t const nodeIdx)
+{
+    ShapedWeights const axesWeights = weights.weights();
+    ONNXTRT_CHECK_NODE((axesWeights.type == ::ONNX_NAMESPACE::TensorProto::INT32)
+            || (axesWeights.type == ::ONNX_NAMESPACE::TensorProto::INT64),
+        "Axis input must resolve to INT32 or INT64 weights!", node, nodeIdx, ErrorCode::kINVALID_NODE);
+
+    std::vector<int64_t> axes64;
+    weightsToVector<int64_t>(weights, &axes64);
+    axes->reserve(axes64.size());
+    for (int64_t const axis : axes64)
+    {
+        ONNXTRT_CHECK_NODE(axis >= std::numeric_limits<int32_t>::lowest()
+                && axis <= std::numeric_limits<int32_t>::max(),
+            "Axis input contains a value outside INT32 range: " << axis, node, nodeIdx, ErrorCode::kINVALID_NODE);
+        axes->push_back(static_cast<int32_t>(axis));
+    }
+}
+
+} // namespace
+
+// Backward traverse the graph to retrieve input weights from a Constant node, applying any Cast layers on the path.
+ShapedWeights getWeightsFromIdentityOrConstant(ImporterContext* ctx, nvinfer1::ITensor* input)
+{
+    auto& network = *ctx->network();
+    // Const node output -> const node mapping.
+    std::unordered_map<nvinfer1::ITensor*, nvinfer1::IConstantLayer*> constNodeToOutputMap;
+    // Identity node output -> identity/cast node mapping.
+    std::unordered_map<nvinfer1::ITensor*, nvinfer1::ILayer*> identityCastNodeToOutputMap;
+    std::vector<nvinfer1::DataType> castTargetTypes;
+
+    // Collect all the constant, identity nodes from network.
+    int32_t nbLayers = network.getNbLayers();
+    for (int32_t i = 0; i < nbLayers; ++i)
+    {
+        nvinfer1::ILayer* layer = N_CHECK(network.getLayer(i));
+        if (layer->getType() == nvinfer1::LayerType::kCONSTANT)
+        {
+            constNodeToOutputMap[layer->getOutput(0)] = static_cast<nvinfer1::IConstantLayer*>(layer);
+        }
+        else if ((layer->getType() == nvinfer1::LayerType::kIDENTITY)
+            || (layer->getType() == nvinfer1::LayerType::kCAST))
+        {
+            identityCastNodeToOutputMap[layer->getOutput(0)] = layer;
+        }
+    }
+    // Follow cast/identity nodes before current node.
+    auto findIdenityIter = identityCastNodeToOutputMap.find(input);
+    while (findIdenityIter != identityCastNodeToOutputMap.end())
+    {
+        auto* const layer = findIdenityIter->second;
+        if (layer->getType() == nvinfer1::LayerType::kCAST)
+        {
+            castTargetTypes.push_back(static_cast<nvinfer1::ICastLayer*>(layer)->getToType());
+        }
+        input = layer->getInput(0);
+        findIdenityIter = identityCastNodeToOutputMap.find(input);
+    }
+    // Find out the weights from constant node.
+    auto findConstIter = constNodeToOutputMap.find(input);
+    if (findConstIter != constNodeToOutputMap.end())
+    {
+        auto weights = findConstIter->second->getWeights();
+        ShapedWeights foldedWeights{
+            trtDataTypeToONNX(weights.type), const_cast<void*>(weights.values), findConstIter->second->getDimensions()};
+        for (auto const castTargetType : std::ranges::reverse_view(castTargetTypes))
+        {
+            foldedWeights = castConstantWeights(ctx, foldedWeights, castTargetType);
+            if (!resolvedWeights(foldedWeights))
+            {
+                return ShapedWeights{};
+            }
+        }
+        return foldedWeights;
+    }
+    return ShapedWeights{};
 }
 
 NodeOutputs reduceTensor(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, size_t const nodeIdx,
@@ -1641,15 +1835,27 @@ NodeOutputs reduceTensor(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const
     bool keepdims = attrs.get("keepdims", 1);
     int32_t ndim = tensor.getDimensions().nbDims;
     std::vector<int32_t> axes;
-    if (attrs.count("axes"))
+    if (attrs.contains("axes"))
     {
         axes = attrs.get<std::vector<int32_t>>("axes");
     }
     else if (!inputAxes.isNullTensor())
     {
-        ONNXTRT_CHECK_NODE(
-            inputAxes.is_weights(), "Axis input must be an initializer!", node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
-        weightsToVector<int32_t>(inputAxes.weights(), &axes);
+        // Opset 18 turns axes into an input. IReduceLayer needs the axes at build time, so a
+        // Constant->Cast/Identity axes chain (a common export pattern, e.g. Constant->Cast(int64))
+        // is folded back to its constant weights rather than rejected outright.
+        if (inputAxes.is_weights())
+        {
+            weightsToAxesVector(inputAxes.weights(), &axes, node, nodeIdx);
+        }
+        else
+        {
+            ShapedWeights const axesWeights = getWeightsFromIdentityOrConstant(ctx, &inputAxes.tensor());
+            ONNXTRT_CHECK_NODE(resolvedWeights(axesWeights),
+                "Axis input must resolve to a build-time constant (an initializer or a constant-foldable subgraph)!",
+                node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+            weightsToAxesVector(axesWeights, &axes, node, nodeIdx);
+        }
     }
     // It's possible that the axes tensor, axes initializer, or axes attribute was empty. Handle such cases here.
     if (axes.empty())
@@ -2056,11 +2262,12 @@ NodeOutputs convMultiInput(ImporterContext* ctx, const ::ONNX_NAMESPACE::NodePro
     return {{outputTensor}};
 }
 
-nvinfer1::ITensor* unsqueezeTensor(ImporterContext* ctx, nvinfer1::ITensor& tensor, std::vector<int32_t> const& axes)
+nvinfer1::ITensor* unsqueezeTensor(ImporterContext* ctx, nvinfer1::ITensor& tensor, std::span<int32_t const> axes)
 {
-    auto* axesTensor
-        = N_CHECK(addConstant(ctx, axes, ::ONNX_NAMESPACE::TensorProto::INT32, {1, {static_cast<int64_t>(axes.size())}})
-                      ->getOutput(0));
+    std::vector<int32_t> const axesVec(axes.begin(), axes.end());
+    auto* axesTensor = N_CHECK(
+        addConstant(ctx, axesVec, ::ONNX_NAMESPACE::TensorProto::INT32, {1, {static_cast<int64_t>(axesVec.size())}})
+            ->getOutput(0));
     auto* unsqueezeLayer = N_CHECK(ctx->network()->addUnsqueeze(tensor, *axesTensor));
     auto* unsqueezedTensor = N_CHECK(unsqueezeLayer->getOutput(0));
     LOG_VERBOSE("Original shape: " << shapeOf(tensor) << ", unsqueezing to: " << shapeOf(*unsqueezedTensor));

--- a/importerUtils.hpp
+++ b/importerUtils.hpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <limits>
 #include <numeric>
+#include <span>
 #include <sstream>
 #include <typeindex>
 #include <unordered_map>
@@ -93,11 +94,6 @@ inline bool operator==(nvinfer1::Dims const& a, nvinfer1::Dims const& b)
     return true;
 }
 
-inline bool operator!=(nvinfer1::Dims const& a, nvinfer1::Dims const& b)
-{
-    return !(a == b);
-}
-
 enum ScaleOp
 {
     kSHIFT,
@@ -157,6 +153,10 @@ bool shiftIsAllZeros(ShapedWeights const& shiftInt8);
 
 // Helper function to create zero shifts for QuantizeLinear/DequantizeLinear ops
 onnx2trt::ShapedWeights createZeroShifts(onnx2trt::ShapedWeights const& shiftInt8, int32_t type, ImporterContext* ctx);
+
+//! Backward-traverse Cast/Identity nodes to recover constant weights feeding a tensor.
+//! \return Default-constructed weights when the chain does not terminate in a Constant node.
+[[nodiscard]] ShapedWeights getWeightsFromIdentityOrConstant(ImporterContext* ctx, nvinfer1::ITensor* input);
 
 // Helper function to create a tensor of all zeros with the same shape as a data tensor
 nvinfer1::ITensor* createZeroTensor(ImporterContext* ctx, nvinfer1::ITensor* data);
@@ -321,11 +321,11 @@ nvinfer1::ITensor* transposeTensor(ImporterContext* ctx, const ::ONNX_NAMESPACE:
 ::ONNX_NAMESPACE::TensorProto_DataType trtDataTypeToONNX(nvinfer1::DataType dt);
 
 // Helper function to import ONNX unary ops into TRT
-NodeOutputs unaryHelper(ImporterContext* ctx, const ::ONNX_NAMESPACE::NodeProto& node, size_t const nodeIdx,
+NodeOutputs unaryHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, size_t const nodeIdx,
     TensorOrWeights& input, nvinfer1::UnaryOperation op);
 
 // Helper function to unsqueeze tensors on a given set of axes
-nvinfer1::ITensor* unsqueezeTensor(ImporterContext* ctx, nvinfer1::ITensor& tensor, std::vector<int32_t> const& axes);
+nvinfer1::ITensor* unsqueezeTensor(ImporterContext* ctx, nvinfer1::ITensor& tensor, std::span<int32_t const> axes);
 
 // Helper function to calculate and return the expected output shape of a resize given the resize scale weights or scale
 // tensor.
@@ -344,31 +344,38 @@ void weightsToVector(TensorOrWeights weights, std::vector<WeightType>* weightVec
             || (sWeights.type == ::ONNX_NAMESPACE::TensorProto::FLOAT16),
         "Found invalid weights type of: " << sWeights.type,
         ErrorCode::kINVALID_NODE);
-    weightVector->resize(sWeights.count());
+    size_t const nbWeights = sWeights.count();
+    weightVector->resize(nbWeights);
+    if (nbWeights == 0)
+    {
+        return;
+    }
+    ONNXTRT_CHECK(sWeights.values != nullptr, "Cannot convert weights with null values to a vector!",
+        ErrorCode::kINVALID_NODE);
     if (sWeights.type == ::ONNX_NAMESPACE::TensorProto::INT64)
     {
         auto array_start = static_cast<int64_t*>(sWeights.values);
-        std::copy(array_start, array_start + sWeights.count(), weightVector->begin());
+        std::copy(array_start, array_start + nbWeights, weightVector->begin());
     }
     else if (sWeights.type == ::ONNX_NAMESPACE::TensorProto::INT32)
     {
         auto array_start = static_cast<int32_t*>(sWeights.values);
-        std::copy(array_start, array_start + sWeights.count(), weightVector->begin());
+        std::copy(array_start, array_start + nbWeights, weightVector->begin());
     }
     else if (sWeights.type == ::ONNX_NAMESPACE::TensorProto::BOOL)
     {
         auto array_start = static_cast<bool*>(sWeights.values);
-        std::copy(array_start, array_start + sWeights.count(), weightVector->begin());
+        std::copy(array_start, array_start + nbWeights, weightVector->begin());
     }
     else if (sWeights.type == ::ONNX_NAMESPACE::TensorProto::FLOAT)
     {
         auto array_start = static_cast<float*>(sWeights.values);
-        std::copy(array_start, array_start + sWeights.count(), weightVector->begin());
+        std::copy(array_start, array_start + nbWeights, weightVector->begin());
     }
     else if (sWeights.type == ::ONNX_NAMESPACE::TensorProto::FLOAT16)
     {
         auto array_start = static_cast<half_float::half*>(sWeights.values);
-        std::copy(array_start, array_start + sWeights.count(), weightVector->begin());
+        std::copy(array_start, array_start + nbWeights, weightVector->begin());
     }
 }
 

--- a/onnxOpCheckers.cpp
+++ b/onnxOpCheckers.cpp
@@ -103,7 +103,7 @@ void randomUniformCheckHelper(
     // Set datatype of output:
     //      RandomUniform: dype is required and defaults to 1
     //      RandomUniformLike: dtype is optional and defaults to the same type as the input
-    if (attrs.count("dtype"))
+    if (attrs.contains("dtype"))
     {
         auto dtype = attrs.get<int32_t>("dtype", 1);
         if (dtype != ::ONNX_NAMESPACE::TensorProto::FLOAT && dtype != ::ONNX_NAMESPACE::TensorProto::FLOAT16)
@@ -122,7 +122,7 @@ void randomNormalCheckHelper(
     // Set datatype of output:
     //      RandomNormal: dype is required and defaults to 1
     //      RandomNormalLike: dtype is optional and defaults to the same type as the input
-    if (attrs.count("dtype"))
+    if (attrs.contains("dtype"))
     {
         auto dtype = attrs.get<int32_t>("dtype", 1);
         if (dtype != ::ONNX_NAMESPACE::TensorProto::FLOAT && dtype != ::ONNX_NAMESPACE::TensorProto::FLOAT16)
@@ -194,7 +194,7 @@ DEFINE_OP_CHECKER(Attention)
     STATIC_CHECK(softcap == 0.0 && "Setting softcap is not supported in TensorRT Attention.",
         ErrorCode::kUNSUPPORTED_NODE, node, errors, nodeIndex);
 
-    bool const hasSoftmaxPrecision = static_cast<bool>(attrs.count("softmax_precision"));
+    bool const hasSoftmaxPrecision = static_cast<bool>(attrs.contains("softmax_precision"));
     STATIC_CHECK(!hasSoftmaxPrecision && "Setting softmax precision is not supported in TensorRT Attention.",
         ErrorCode::kUNSUPPORTED_NODE, node, errors, nodeIndex);
 }
@@ -260,7 +260,11 @@ DEFINE_OP_CHECKER(Constant)
     // serialized iNetworkDefinition which does not have this check.
     if (attrs.get<std::vector<float>>("trt_outputs_range_min", {}).empty())
     {
-        STATIC_CHECK((!attrs.count("sparse_value")) && (!attrs.count("value_string")) && (!attrs.count("value_strings"))
+        // The next NOLINT suppresses a modernize-use-emplace warning that originates from
+        // `push_back` inside the STATIC_CHECK / ADD_STATIC_ERROR macro expansion in
+        // parsers/onnx/Status.hpp; fixing the macro is out of scope for this MR.
+        // NOLINTNEXTLINE(modernize-use-emplace)
+        STATIC_CHECK((!attrs.contains("sparse_value")) && (!attrs.contains("value_string")) && (!attrs.contains("value_strings"))
             && "This version of TensorRT does not support the sparse_value, value_string and value_strings attributes.",
         ErrorCode::kUNSUPPORTED_NODE, node, errors, nodeIndex);
     }
@@ -347,6 +351,8 @@ DEFINE_OP_EMPTY_CHECKER(TRT_BlockQuantize)
 DEFINE_OP_EMPTY_CHECKER(TRT_BlockDequantize)
 
 DECLARE_OP_CHECKER(Mul);
+
+DEFINE_OP_EMPTY_CHECKER(DFT)
 
 DEFINE_OP_EMPTY_CHECKER(Div)
 
@@ -886,7 +892,7 @@ DEFINE_OP_CHECKER(TopK)
     if (ctx->getOpsetVersion() < 10)
     {
         STATIC_CHECK(
-            (attrs.count("k")) && "Attribute k is missing.", ErrorCode::kINVALID_NODE, node, errors, nodeIndex);
+            (attrs.contains("k")) && "Attribute k is missing.", ErrorCode::kINVALID_NODE, node, errors, nodeIndex);
     }
 }
 
@@ -1070,11 +1076,6 @@ DEFINE_OP_CHECKER(ConcatFromSequence)
 }
 
 DEFINE_OP_CHECKER(ConvInteger)
-{
-    STATIC_CHECK(false, ErrorCode::kUNSUPPORTED_NODE, node, errors, nodeIndex);
-}
-
-DEFINE_OP_CHECKER(DFT)
 {
     STATIC_CHECK(false, ErrorCode::kUNSUPPORTED_NODE, node, errors, nodeIndex);
 }

--- a/onnxOpImporters.cpp
+++ b/onnxOpImporters.cpp
@@ -30,10 +30,15 @@
 #include <iterator>
 #include <limits> // For std::numeric_limits
 #include <numeric> // For std::iota
+#include <span>
 #include <sstream>
 #include <string_view>
 #include <tuple>
 #include <unordered_set>
+
+#ifdef __cpp_lib_math_constants
+#include <numbers>
+#endif // __cpp_lib_math_constants
 
 namespace onnx2trt
 {
@@ -230,6 +235,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Attention)
 
     return {{&reshapeOutputTensor(*attention->getOutput(0), ctx, needsReshape)}};
 }
+
 
 DEFINE_BUILTIN_OP_IMPORTER(TRT_QuantizedAttention)
 {
@@ -832,16 +838,85 @@ NodeOutputs elementwiseClipHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::NodePr
     return {{upperClip}};
 }
 
+// If `bound` is a single-element float/fp16/bf16 constant, write its value to `value` and return
+// true; otherwise (a tensor, null, non-float, or non-scalar bound) return false. Clip min/max
+// bounds are scalars, so the other forms are simply not the constant-bound case handled here.
+[[nodiscard]] bool tryGetScalarFloatConstantBound(TensorOrWeights const& bound, float& value)
+{
+    if (!bound.is_weights() || bound.isNullTensor())
+    {
+        return false;
+    }
+    auto const& weights = bound.weights();
+    bool const isFloatType = weights.type == ::ONNX_NAMESPACE::TensorProto::FLOAT
+        || weights.type == ::ONNX_NAMESPACE::TensorProto::FLOAT16
+        || weights.type == ::ONNX_NAMESPACE::TensorProto::BFLOAT16;
+    if (!isFloatType || weights.count() != 1)
+    {
+        return false;
+    }
+    value = getSingleValueAsFloat(weights);
+    return true;
+}
+
+// A scalar bound that is an open-direction infinity (min == -inf or max == +inf) cannot use the
+// kCLIP activation path (setAlpha/setBeta reject non-finite values). Such a bound means "no bound on
+// that side", so it forces the elementwise kMIN/kMAX path, which clamps against the real value and
+// handles the infinity correctly. A wrong-direction infinity (min == +inf or max == -inf) would
+// clamp every element to a single value; like NaN it is treated as malformed and left for the
+// activation path's setAlpha/setBeta to reject, matching the pre-opset-11 attribute handling below.
+[[nodiscard]] bool isOpenInfiniteScalarBound(TensorOrWeights const& bound, bool isLowerBound)
+{
+    float value{};
+    if (!tryGetScalarFloatConstantBound(bound, value))
+    {
+        return false;
+    }
+    // Open direction: -inf for the lower bound, +inf for the upper bound.
+    return std::isinf(value) && std::signbit(value) == isLowerBound;
+}
+
+// A scalar NaN constant bound is malformed, not an open bound. It must reach the kCLIP activation
+// path so setAlpha/setBeta reject it; it must not be dragged onto the elementwise path by a sibling
+// open-direction infinity, which would silently accept the malformed model.
+[[nodiscard]] bool isNaNScalarBound(TensorOrWeights const& bound)
+{
+    float value{};
+    return tryGetScalarFloatConstantBound(bound, value) && std::isnan(value);
+}
+
+// Map an open-bound infinity to the dtype limit so the kCLIP activation path applies: min == -inf
+// becomes lowest(), max == +inf becomes max(). Any other value -- finite, or a wrong-direction
+// infinity such as min == +inf -- is returned unchanged for setAlpha/setBeta to handle.
+[[nodiscard]] float openInfinityToLimit(float value, bool isLowerBound)
+{
+    if (std::isinf(value) && std::signbit(value) == isLowerBound)
+    {
+        return isLowerBound ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max();
+    }
+    return value;
+}
+
 DEFINE_BUILTIN_OP_IMPORTER(Clip)
 {
     checkNotInvalidType(inputs.at(0), {"UINT8"}, node, nodeIdx);
     // For INT32 and multi-input clips, use elementwise operators instead.
-    size_t numInputs = inputs.size();
-    bool elementwiseClip = inputs.at(0).isInt32() || inputs.at(0).isInt64();
-    for (size_t i = 1; i < numInputs; i++)
-    {
-        elementwiseClip |= inputs.at(i).is_tensor();
-    }
+    size_t const numInputs = inputs.size();
+    // The bounds are inputs [1, numInputs): input 1 is "min" (open at -inf), input 2 is "max"
+    // (open at +inf).
+    auto const bounds = std::span(inputs).subspan(1);
+    // A tensor bound (runtime -- no activation path) or an INT input forces the elementwise
+    // kMIN/kMAX path. An open-direction constant infinity (e.g. clip(x, eps, +inf) ahead of a log)
+    // also forces it -- unless a sibling bound is a NaN constant, which is malformed and must reach
+    // the activation path to be rejected rather than silently accepted, so the NaN vetoes the
+    // open-infinity routing. See isOpenInfiniteScalarBound / isNaNScalarBound.
+    bool const hasNaNConstantBound = std::ranges::any_of(bounds, isNaNScalarBound);
+    bool const hasOpenInfiniteBound
+        = (numInputs > 1 && isOpenInfiniteScalarBound(inputs.at(1), /*isLowerBound=*/true))
+        || (numInputs > 2 && isOpenInfiniteScalarBound(inputs.at(2), /*isLowerBound=*/false));
+    bool const elementwiseClip = inputs.at(0).isInt32() || inputs.at(0).isInt64()
+        || std::ranges::any_of(bounds, &TensorOrWeights::is_tensor)
+        || (hasOpenInfiniteBound && !hasNaNConstantBound);
     if (elementwiseClip)
     {
         auto type = convertToTensor(inputs.at(0), ctx).getType();
@@ -851,25 +926,23 @@ DEFINE_BUILTIN_OP_IMPORTER(Clip)
             "type is "
                 + getTrtDtypeName(type) + ".",
             node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
-        if (type == DataType::kHALF)
+        //! Call elementwiseClipHelper<T> with the given \p onnxType.
+        auto eltwiseClipHelper = [&]<typename T>(std::type_identity<T>, int32_t onnxType) -> decltype(auto) {
+            return elementwiseClipHelper<T>(ctx, node, inputs, numInputs, onnxType);
+        };
+        switch (type)
         {
-            return elementwiseClipHelper<half_float::half>(
-                ctx, node, inputs, numInputs, ::ONNX_NAMESPACE::TensorProto::FLOAT16);
+        case DataType::kHALF:
+            return eltwiseClipHelper(std::type_identity<half_float::half>{}, ::ONNX_NAMESPACE::TensorProto::FLOAT16);
+        case DataType::kBF16:
+            return eltwiseClipHelper(std::type_identity<BFloat16>{}, ::ONNX_NAMESPACE::TensorProto::BFLOAT16);
+        case DataType::kFLOAT:
+            return eltwiseClipHelper(std::type_identity<float>{}, ::ONNX_NAMESPACE::TensorProto::FLOAT);
+        case DataType::kINT64:
+            return eltwiseClipHelper(std::type_identity<int64_t>{}, ::ONNX_NAMESPACE::TensorProto::INT64);
+        default:
+            return eltwiseClipHelper(std::type_identity<int32_t>{}, ::ONNX_NAMESPACE::TensorProto::INT32);
         }
-        if (type == DataType::kBF16)
-        {
-            return elementwiseClipHelper<BFloat16>(
-                ctx, node, inputs, numInputs, ::ONNX_NAMESPACE::TensorProto::BFLOAT16);
-        }
-        if (type == DataType::kFLOAT)
-        {
-            return elementwiseClipHelper<float>(ctx, node, inputs, numInputs, ::ONNX_NAMESPACE::TensorProto::FLOAT);
-        }
-        if (type == DataType::kINT64)
-        {
-            return elementwiseClipHelper<int64_t>(ctx, node, inputs, numInputs, ::ONNX_NAMESPACE::TensorProto::INT64);
-        }
-        return elementwiseClipHelper<int32_t>(ctx, node, inputs, numInputs, ::ONNX_NAMESPACE::TensorProto::INT32);
     }
 
     // Activation path only supports float/half initializers
@@ -911,8 +984,10 @@ DEFINE_BUILTIN_OP_IMPORTER(Clip)
     }
     else
     {
-        alpha = attrs.get("min", std::numeric_limits<float>::lowest());
-        beta = attrs.get("max", std::numeric_limits<float>::max());
+        // openInfinityToLimit maps the open-bound infinities (min == -inf, max == +inf) to the dtype
+        // limit so the activation path applies; wrong-direction infinities are left to be rejected.
+        alpha = openInfinityToLimit(attrs.get("min", std::numeric_limits<float>::lowest()), /*isLowerBound=*/true);
+        beta = openInfinityToLimit(attrs.get("max", std::numeric_limits<float>::max()), /*isLowerBound=*/false);
     }
 
     return activationHelper(ctx, node, nodeIdx, inputs, nvinfer1::ActivationType::kCLIP, &alpha, &beta);
@@ -955,7 +1030,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Constant)
 
     if (ctx->getOpsetVersion() >= 12)
     {
-        if (attrs.count("value_float"))
+        if (attrs.contains("value_float"))
         {
             ShapedWeights convertedWeights = ctx->createNamedTempWeights(::ONNX_NAMESPACE::TensorProto::FLOAT, {0, {}});
             float value = attrs.get<float>("value_float");
@@ -963,7 +1038,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Constant)
             return {{convertedWeights}};
         }
 
-        if (attrs.count("value_floats"))
+        if (attrs.contains("value_floats"))
         {
             std::vector<float> values = attrs.get<std::vector<float>>("value_floats");
             int32_t valueSize = values.size();
@@ -972,7 +1047,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Constant)
             std::memcpy(convertedWeights.values, values.data(), convertedWeights.count() * sizeof(float));
             return {{convertedWeights}};
         }
-        if (attrs.count("value_int"))
+        if (attrs.contains("value_int"))
         {
             ShapedWeights convertedWeights = ctx->createNamedTempWeights(::ONNX_NAMESPACE::TensorProto::INT64, {0, {}});
             int64_t value = attrs.get<int64_t>("value_int");
@@ -980,7 +1055,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Constant)
             return {{convertedWeights}};
         }
 
-        if (attrs.count("value_ints"))
+        if (attrs.contains("value_ints"))
         {
             std::vector<int64_t> values = attrs.get<std::vector<int64_t>>("value_ints");
             int32_t valueSize = values.size();
@@ -1253,7 +1328,7 @@ DEFINE_BUILTIN_OP_IMPORTER(ConvTranspose)
     // 3. Use specified "pads" values from the node. Pad the resulting output vector with values from output_padding.
 
     auto autoPadMode = attrs.get("auto_pad", std::string("NOTSET"));
-    if (attrs.count("output_shape") && autoPadMode == std::string("NOTSET"))
+    if (attrs.contains("output_shape") && autoPadMode == std::string("NOTSET"))
     {
         outputShape = attrs.get<nvinfer1::Dims>("output_shape");
 
@@ -1554,49 +1629,6 @@ DEFINE_BUILTIN_OP_IMPORTER(DistCollective)
     RETURN_FIRST_OUTPUT(layer, node, nodeIdx);
 }
 
-// Backward traverse the graph to retrieve the input weights from the constant node. We allow skipping all cast/identity
-// nodes until reaching the constant node.
-ShapedWeights getWeightsFromIdentityOrConstant(nvinfer1::INetworkDefinition& network, nvinfer1::ITensor* input)
-{
-    // Const node output -> const node mapping.
-    std::unordered_map<nvinfer1::ITensor*, nvinfer1::IConstantLayer*> constNodeToOutputMap;
-    // Identity node output -> identity/cast node mapping.
-    std::unordered_map<nvinfer1::ITensor*, nvinfer1::ILayer*> identityCastNodeToOutputMap;
-
-    // Collect all the constant, identity nodes from network.
-    int32_t nbLayers = network.getNbLayers();
-    for (int32_t i = 0; i < nbLayers; ++i)
-    {
-        nvinfer1::ILayer* layer = N_CHECK(network.getLayer(i));
-        if (layer->getType() == nvinfer1::LayerType::kCONSTANT)
-        {
-            constNodeToOutputMap[layer->getOutput(0)] = static_cast<nvinfer1::IConstantLayer*>(layer);
-        }
-        else if ((layer->getType() == nvinfer1::LayerType::kIDENTITY)
-            || (layer->getType() == nvinfer1::LayerType::kCAST))
-        {
-            identityCastNodeToOutputMap[layer->getOutput(0)] = layer;
-        }
-    }
-    // Skip all the cast/identity nodes before current node.
-    auto findIdenityIter = identityCastNodeToOutputMap.find(input);
-    while (findIdenityIter != identityCastNodeToOutputMap.end())
-    {
-        input = findIdenityIter->second->getInput(0);
-        findIdenityIter = identityCastNodeToOutputMap.find(input);
-    }
-    // Find out the weights from constant node.
-    auto findConstIter = constNodeToOutputMap.find(input);
-    if (findConstIter != constNodeToOutputMap.end())
-    {
-        auto weights = findConstIter->second->getWeights();
-        return ShapedWeights(
-            trtDataTypeToONNX(weights.type), const_cast<void*>(weights.values), findConstIter->second->getDimensions());
-    }
-    // Return empty weights when not found.
-    return ShapedWeights{};
-}
-
 // This is a helper function for QuantizeLinear/DequantizeLinear
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 NodeOutputs QuantDequantLinearHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const& node, size_t nodeIdx,
@@ -1791,7 +1823,7 @@ NodeOutputs QuantDequantLinearHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::Nod
             if (zeroPtInput.is_tensor())
             {
                 // Look backward to find out the original weights in "Constant" node.
-                zeroPoint = getWeightsFromIdentityOrConstant(*ctx->network(), &zeroPtInput.tensor());
+                zeroPoint = getWeightsFromIdentityOrConstant(ctx, &zeroPtInput.tensor());
             }
             else
             {
@@ -1852,7 +1884,7 @@ NodeOutputs QuantDequantLinearHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::Nod
     int32_t axis = attrs.get<int32_t>("axis", 1);
 
     // Axis attribute was first introduced in opset 13. Use a default of 0 for older models.
-    if (ctx->getOpsetVersion() < 13 && !attrs.count("axis"))
+    if (ctx->getOpsetVersion() < 13 && !attrs.contains("axis"))
     {
         axis = 0;
     }
@@ -2402,7 +2434,7 @@ DEFINE_BUILTIN_OP_IMPORTER(EyeLike)
 
     // The data type can be specified by the 'dtype' argument
     DataType dtype = tensor.getType();
-    if (attrs.count("dtype"))
+    if (attrs.contains("dtype"))
     {
         auto onnxType = attrs.get<int32_t>("dtype");
         ONNXTRT_CHECK_NODE(
@@ -4819,7 +4851,7 @@ NodeOutputs randomHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const
     // Set datatype of output:
     //      RandomUniform / RandomNormal: dtype is required and defaults to 1
     //      RandomUniformLike / RandomNormalLike: dtype is optional and defaults to the same type as the input
-    if (attrs.count("dtype"))
+    if (attrs.contains("dtype"))
     {
         auto dtype = attrs.get<int32_t>("dtype", 1);
         switch (dtype)
@@ -4843,7 +4875,7 @@ NodeOutputs randomHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProto const
     fillLayer->setBeta(beta);
 
     // TensorRT does not support "seed" field now. The support will be added in future versions.
-    if (attrs.count("seed"))
+    if (attrs.contains("seed"))
     {
         LOG_WARNING(
             "TensorRT currently ignores the \"seed\" field in RandomUniform or RandomNormal op. Random seeds will be "
@@ -5471,7 +5503,8 @@ DEFINE_BUILTIN_OP_IMPORTER(RotaryEmbedding)
 
     if (inputIs3D) // (batchSize, sequenceLength, hiddenSize=numHeads * headSize)
     {
-        ONNXTRT_CHECK_NODE(attrs.count("num_heads"), "num_heads attribute is required for 3D input tensors.", node, nodeIdx, ErrorCode::kINVALID_NODE);
+        ONNXTRT_CHECK_NODE(attrs.contains("num_heads"), "num_heads attribute is required for 3D input tensors.", node,
+            nodeIdx, ErrorCode::kINVALID_NODE);
         int32_t const numHeads = attrs.get<int32_t>("num_heads");
         int32_t const hiddenSize = input->getDimensions().d[2];
         ONNXTRT_CHECK_NODE(hiddenSize % numHeads == 0, "hiddenSize must be divisible by num_heads.", node, nodeIdx,
@@ -5527,7 +5560,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Reshape)
     if (ctx->getOpsetVersion() >= 5)
     {
         OnnxAttrs attrs{node, ctx};
-        if (attrs.count("allowzero"))
+        if (attrs.contains("allowzero"))
         {
             allowZero = attrs.get<int32_t>("allowzero");
             if (ctx->getOpsetVersion() < 14)
@@ -6005,19 +6038,24 @@ DEFINE_BUILTIN_OP_IMPORTER(GridSample)
         sampleMode = nvinfer1::SampleMode::kREFLECT;
     }
 
-    auto mode = attrs.get<std::string>("mode", "bilinear");
+    auto mode = attrs.get<std::string>("mode", "linear");
     nvinfer1::InterpolationMode interpolationMode{nvinfer1::InterpolationMode::kNEAREST};
     if (mode == "nearest")
     {
         interpolationMode = nvinfer1::InterpolationMode::kNEAREST;
     }
-    else if (mode == "bilinear")
+    else if (mode == "linear" || mode == "bilinear")
     {
         interpolationMode = nvinfer1::InterpolationMode::kLINEAR;
     }
-    else if (mode == "bicubic")
+    else if (mode == "cubic" || mode == "bicubic")
     {
         interpolationMode = nvinfer1::InterpolationMode::kCUBIC;
+    }
+    else
+    {
+        ONNXTRT_CHECK_NODE(
+            false, "Unsupported interpolation mode: " << mode, node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE_ATTR);
     }
 
     bool const alignCorners{attrs.get<int32_t>("align_corners", 0) == 1};
@@ -6069,6 +6107,174 @@ NodeOutputs scatterPluginHelper(ImporterContext* ctx, ::ONNX_NAMESPACE::NodeProt
     auto* layer = N_CHECK(ctx->network()->addPluginV3(pluginInputs.data(), pluginInputs.size(), nullptr, 0, *plugin));
     ctx->registerLayer(layer, node);
     RETURN_FIRST_OUTPUT(layer, node, nodeIdx);
+}
+
+// ONNX defines the inverse DFT to output with a 1/N factor, but cuFFT's inverse is unnormalized,
+// and returns N * result. This scales the output by 1/N.
+// For C2R, N is at output axis -1.
+// For C2C, N is at output axis -2. See the table in the DFT importer.
+nvinfer1::ITensor* dftNormalizeInverse(ImporterContext* ctx, nvinfer1::ITensor* out, bool isC2R)
+{
+    int32_t const outRank = out->getDimensions().nbDims;
+    int32_t const nAxis = isC2R ? outRank - 1 : outRank - 2;
+    nvinfer1::Dims scaleShape{};
+    scaleShape.nbDims = outRank;
+    for (int32_t i = 0; i < outRank; ++i)
+    {
+        scaleShape.d[i] = 1;
+    }
+    nvinfer1::ITensor* nLength
+        = castHelper(ctx, getAxisLength(ctx, out, nAxis, scaleShape), nvinfer1::DataType::kFLOAT);
+    nvinfer1::ITensor* one
+        = N_CHECK(addConstantScalar(ctx, 1.0F, ::ONNX_NAMESPACE::TensorProto::FLOAT, outRank)->getOutput(0));
+    nvinfer1::ITensor* scale = getElementWiseResult(ctx, *one, *nLength, nvinfer1::ElementWiseOperation::kDIV);
+    scale = castHelper(ctx, scale, out->getType());
+    return getElementWiseResult(ctx, *out, *scale, nvinfer1::ElementWiseOperation::kPROD);
+}
+
+// DFT maps to one of three cuFFT modes, set by `inverse`, `onesided`, and whether the input
+// is real (innermost axis -1 has size 1) or complex (size 2). Complex uses the interleaved
+// [..., 2] real/imag layout. N is the transformed length, along axis -2.
+//
+//   | inverse | onesided | input                   | mode        | output          |
+//   |---------|----------|-------------------------|-------------|-----------------|
+//   |    0    |    0     | complex [..., N, 2]     | C2C forward | [..., N, 2]     |
+//   |    1    |    0     | complex [..., N, 2]     | C2C inverse | [..., N, 2]     |
+//   |    0    |    1     | real    [..., N, 1]     | R2C         | [..., N/2+1, 2] |
+//   |    1    |    1     | complex [..., N/2+1, 2] | C2R         | [..., N, 1]     |
+//
+// onesided picks C2C versus the real half-spectrum transforms, and inverse picks the
+// direction. The inverse is 1/N normalized in ONNX. cuFFT is unnormalized, so
+// dftNormalizeInverse applies the 1/N scaling. There is no R2R mode: a real signal's
+// Fourier transform is complex.
+DEFINE_BUILTIN_OP_IMPORTER(DFT)
+{
+    OnnxAttrs attrs(node, ctx);
+    int32_t const inverse = attrs.get<int32_t>("inverse", 0);
+    int32_t const onesided = attrs.get<int32_t>("onesided", 0);
+    ONNXTRT_CHECK_NODE(inverse == 0 || inverse == 1, "DFT 'inverse' must be 0 or 1, got " << inverse << ".", node,
+        nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+    ONNXTRT_CHECK_NODE(onesided == 0 || onesided == 1, "DFT 'onesided' must be 0 or 1, got " << onesided << ".", node,
+        nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+
+    nvinfer1::ITensor* input = &convertToTensor(inputs.at(0), ctx);
+    int32_t const rank = input->getDimensions().nbDims;
+    ONNXTRT_CHECK_NODE(
+        rank >= 2, "DFT input must have rank >= 2, got " << rank << ".", node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+
+    // The innermost axis (-1) flags real (1) or complex (2) and must be static.
+    int64_t const lastDim = input->getDimensions().d[rank - 1];
+    ONNXTRT_CHECK_NODE(lastDim == 1 || lastDim == 2,
+        "DFT requires a static innermost axis (-1) of size 1 (real) or 2 (complex), got " << lastDim << ".", node,
+        nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+    bool const realInput = lastDim == 1;
+    bool const hasDftLength = inputs.size() > 1 && !inputs.at(1).isNullTensor();
+    bool const isC2R = inverse != 0 && onesided != 0;
+
+    // The transform axis was an attribute before opset 20, and an optional input in opset 20+.
+    // It must be axis -2, the signal axis just inside the -1 real/imag dim. FFTPlugin maps to
+    // cuFFT, which transforms only innermost axes. An interior axis could be supported in the
+    // future by transposing it to the end, transforming, then transposing back.
+    // See also https://jirasw.nvidia.com/browse/TRT-28174.
+    int32_t axis = -2;
+    if (ctx->getOpsetVersion() >= 20)
+    {
+        if (inputs.size() > 2 && !inputs.at(2).isNullTensor())
+        {
+            ONNXTRT_CHECK_NODE(inputs.at(2).is_weights(),
+                "FFTPlugin requires the DFT 'axis' input to be a build-time constant.", node, nodeIdx,
+                ErrorCode::kUNSUPPORTED_NODE);
+            auto const axisWeights = inputs.at(2).weights();
+            ONNXTRT_CHECK_NODE(
+                axisWeights.count() == 1, "DFT 'axis' must be a scalar.", node, nodeIdx, ErrorCode::kINVALID_NODE);
+            axis = axisWeights.type == ::ONNX_NAMESPACE::TensorProto::INT64
+                ? static_cast<int32_t>(static_cast<int64_t const*>(axisWeights.values)[0])
+                : static_cast<int32_t const*>(axisWeights.values)[0];
+        }
+    }
+    else
+    {
+        axis = attrs.get<int32_t>("axis", 1);
+    }
+    int32_t const normAxis = axis < 0 ? axis + rank : axis;
+    ONNXTRT_CHECK_NODE(normAxis == rank - 2,
+        "FFTPlugin supports DFT only on axis -2, got axis " << axis << " for rank " << rank << ".", node, nodeIdx,
+        ErrorCode::kUNSUPPORTED_NODE);
+
+    // Reject any config outside the four modes in the table above.
+    if (inverse == 0)
+    {
+        if (realInput)
+        {
+            ONNXTRT_CHECK_NODE(onesided != 0, "FFTPlugin supports real-input forward DFT only with onesided=1 (R2C).",
+                node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+        }
+        else
+        {
+            ONNXTRT_CHECK_NODE(onesided == 0,
+                "FFTPlugin supports complex-input forward DFT only with onesided=0 (C2C).", node, nodeIdx,
+                ErrorCode::kUNSUPPORTED_NODE);
+        }
+        ONNXTRT_CHECK_NODE(!hasDftLength, "FFTPlugin does not support dft_length for the forward DFT.", node, nodeIdx,
+            ErrorCode::kUNSUPPORTED_NODE);
+    }
+    else
+    {
+        ONNXTRT_CHECK_NODE(
+            !realInput, "Inverse DFT requires complex input ([..., 2]).", node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE);
+        ONNXTRT_CHECK_NODE(isC2R || !hasDftLength,
+            "FFTPlugin does not support dft_length (padding/truncation) for the inverse C2C DFT.", node, nodeIdx,
+            ErrorCode::kUNSUPPORTED_NODE);
+        ONNXTRT_CHECK_NODE(!isC2R || hasDftLength,
+            "C2R requires explicit dft_length to differentiate even vs odd output length.", node, nodeIdx,
+            ErrorCode::kUNSUPPORTED_NODE);
+    }
+
+    // R2C: drop the -1 real/imag dim ([...,N,1] -> [...,N]) for cuFFT.
+    if (realInput)
+    {
+        input = squeezeTensor(ctx, *input, std::vector<int32_t>{rank - 1});
+    }
+
+    int32_t const ndims = 1;
+    std::vector<nvinfer1::PluginField> fields;
+    fields.emplace_back("inverse", &inverse, nvinfer1::PluginFieldType::kINT32, 1);
+    fields.emplace_back("onesided", &onesided, nvinfer1::PluginFieldType::kINT32, 1);
+    fields.emplace_back("ndims", &ndims, nvinfer1::PluginFieldType::kINT32, 1);
+    auto const plugin = createPlugin(ctx, node, getNodeName(node), kTRT_STD_PLUGIN_NAMESPACE,
+        static_cast<nvinfer1::IPluginCreatorV3One*>(importPluginCreator(ctx, "FFTPlugin", "1")), fields);
+    ONNXTRT_CHECK_NODE(plugin != nullptr, "FFTPlugin was not found in the plugin registry!", node, nodeIdx,
+        ErrorCode::kUNSUPPORTED_NODE);
+
+    std::vector<nvinfer1::ITensor*> pluginInputs{input};
+    std::vector<nvinfer1::ITensor*> shapeInputs;
+    if (isC2R && hasDftLength)
+    {
+        // Reshape the dft_length from scalar to [1]
+        nvinfer1::ITensor* length = &convertToTensor(inputs.at(1), ctx);
+        if (length->getDimensions().nbDims == 0)
+        {
+            length = unsqueezeTensor(ctx, *length, std::array{int32_t{0}});
+        }
+        shapeInputs.push_back(castHelper(ctx, length, nvinfer1::DataType::kINT64));
+    }
+
+    auto* layer = N_CHECK(ctx->network()->addPluginV3(pluginInputs.data(), pluginInputs.size(), shapeInputs.data(),
+        static_cast<int32_t>(shapeInputs.size()), *plugin));
+    ctx->registerLayer(layer, node);
+    nvinfer1::ITensor* out = N_CHECK(layer->getOutput(0));
+
+    if (inverse != 0)
+    {
+        out = dftNormalizeInverse(ctx, out, isC2R);
+    }
+    // C2R: restore the ONNX -1 real/imag dim ([...,N] -> [...,N,1]).
+    if (isC2R)
+    {
+        out = unsqueezeTensor(ctx, *out, std::vector<int32_t>{out->getDimensions().nbDims});
+    }
+
+    return {{out}};
 }
 
 DEFINE_BUILTIN_OP_IMPORTER(ScatterElements)
@@ -6224,8 +6430,8 @@ DEFINE_BUILTIN_OP_IMPORTER(Slice)
         starts = ShapeTensor(1, attrs.get<std::vector<int64_t>>("starts"));
         ends = ShapeTensor(1, attrs.get<std::vector<int64_t>>("ends"));
         // "It's optional. If not present, will be treated as [0, 1, ..., len(starts) - 1]."
-        axes = attrs.count("axes") ? ShapeTensor(1, attrs.get<std::vector<int64_t>>("axes"))
-                                   : iotaShapeVector(starts.size());
+        axes = attrs.contains("axes") ? ShapeTensor(1, attrs.get<std::vector<int64_t>>("axes"))
+                                      : iotaShapeVector(starts.size());
         steps = similar(ctx, starts, 1);
     }
 
@@ -6362,7 +6568,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Split)
     ShapeTensor sizeSliceAxis;
     ShapeTensor sizeSliceAxisLastOne;
     ShapeTensor splitSizesTensor;
-    bool const hasSplitList = (ctx->getOpsetVersion() >= 13) ? (inputs.size() == 2) : attrs.count("split");
+    bool const hasSplitList = (ctx->getOpsetVersion() >= 13) ? (inputs.size() == 2) : attrs.contains("split");
     if (hasSplitList)
     {
         // "Lengths of the parts can be specified using argument split."
@@ -6386,7 +6592,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Split)
             // "Either input 'split' or the attribute 'num_outputs' should be specified, but not both."
             if (ctx->getOpsetVersion() >= 18)
             {
-                ONNXTRT_CHECK_NODE(!attrs.count("num_outputs"),
+                ONNXTRT_CHECK_NODE(!attrs.contains("num_outputs"),
                     "Either 'split' should be provided as an input or 'num_outputs' should be provided as an "
                     "attribute. But not both.",
                     node, nodeIdx, ErrorCode::kINVALID_NODE);
@@ -6405,7 +6611,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Split)
     else
     {
         // In opset >= 18, a new attribute 'num_outputs' has been added.
-        if (ctx->getOpsetVersion() >= 18 && attrs.count("num_outputs"))
+        if (ctx->getOpsetVersion() >= 18 && attrs.contains("num_outputs"))
         {
             ONNXTRT_CHECK_NODE(attrs.get<int32_t>("num_outputs") == static_cast<int32_t>(numOutputs),
                 "The number of node outputs is not the same as the value of 'num_outputs' attribute. num_outputs "
@@ -6491,7 +6697,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Squeeze)
     else
     {
         OnnxAttrs attrs(node, ctx);
-        if (attrs.count("axes"))
+        if (attrs.contains("axes"))
         {
             std::vector<int64_t> axes = attrs.get<std::vector<int64_t>>("axes");
             axesTensor = N_CHECK(
@@ -6532,6 +6738,35 @@ DEFINE_BUILTIN_OP_IMPORTER(Squeeze)
     auto* squeezeLayer = N_CHECK(ctx->network()->addSqueeze(data, *axesTensor));
     ctx->registerLayer(squeezeLayer, node);
     RETURN_FIRST_OUTPUT(squeezeLayer, node, nodeIdx);
+}
+
+// MSVC trips on the variable template std::numbers::pi_v<float> inside a function template
+// (C7510), so bind it to a non-template constant here.
+#ifdef __cpp_lib_math_constants
+constexpr float kSTFT_PI = std::numbers::pi_v<float>;
+#else
+constexpr float kSTFT_PI = static_cast<float>(M_PI);
+#endif // __cpp_lib_math_constants
+
+//! Fill the real/imaginary DFT convolution weights for STFT in the requested storage type \p T.
+//! Coefficients are computed in float and cast to \p T (float, half_float::half, or BFloat16) so the
+//! convolution runs in the input precision in strongly typed networks.
+template <typename T>
+void fillStftDftWeights(ShapedWeights& realWeights, ShapedWeights& imaginaryWeights, float const* window,
+    int64_t dftUniqueBins, int64_t frameLength)
+{
+    for (int64_t w = 0; w < dftUniqueBins; ++w)
+    {
+        for (int64_t k = 0; k < frameLength; ++k)
+        {
+            int64_t const weightIndex = w * frameLength + k;
+
+            auto const angle = -2.0F * kSTFT_PI * w * k / frameLength;
+
+            realWeights.at<T>(weightIndex) = static_cast<T>(std::cos(angle) * window[k]);
+            imaginaryWeights.at<T>(weightIndex) = static_cast<T>(std::sin(angle) * window[k]);
+        }
+    }
 }
 
 DEFINE_BUILTIN_OP_IMPORTER(STFT)
@@ -6581,10 +6816,17 @@ DEFINE_BUILTIN_OP_IMPORTER(STFT)
         input = squeezeTensor(ctx, *input, axes);
     }
 
-    // Float only support.
-    ONNXTRT_CHECK_NODE(input->getType() == nvinfer1::DataType::kFLOAT,
-        "Input to STFT must be Float32. Received type: " << input->getType(), node, nodeIdx,
+    // STFT now supports FP32, FP16, and BF16.
+    // The convolution decomposition runs in the input precision.
+    auto const inputType = input->getType();
+    ONNXTRT_CHECK_NODE(inputType == nvinfer1::DataType::kFLOAT || inputType == nvinfer1::DataType::kHALF
+            || inputType == nvinfer1::DataType::kBF16,
+        "Input to STFT must be FP32, FP16, or BF16. Received type: " << inputType, node, nodeIdx,
         ErrorCode::kUNSUPPORTED_NODE);
+    auto const onnxWeightType = (inputType == nvinfer1::DataType::kHALF)
+        ? ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT16
+        : (inputType == nvinfer1::DataType::kBF16 ? ::ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16
+                                                  : ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
 
     int64_t frameStep{0};
     ShapedWeights windowWeights = ShapedWeights::empty(::ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
@@ -6630,6 +6872,13 @@ DEFINE_BUILTIN_OP_IMPORTER(STFT)
         }
     }
 
+    ONNXTRT_CHECK_NODE(
+        windowWeights.shape.nbDims == 1, "window must be 1D for STFT.", node, nodeIdx, ErrorCode::kINVALID_NODE);
+    ONNXTRT_CHECK_NODE(windowWeights.shape.d[0] == frameLength,
+        "window length must match frame_length. window length = " << windowWeights.shape.d[0]
+                                                                  << ", frame_length = " << frameLength << ".",
+        node, nodeIdx, ErrorCode::kINVALID_NODE);
+
     // Calculate dftUniqueBins depending on the onesided attribute.
     int64_t dftUniqueBins = onesided == 1 ? ((frameLength >> 1) + 1) : frameLength;
 
@@ -6650,26 +6899,39 @@ DEFINE_BUILTIN_OP_IMPORTER(STFT)
                 imagWeights[w, 1, 1, k] = sin(-2 * pi * k * w / n) * window[k]
     */
 
-    auto realWeights = ctx->createNamedTempWeights(
-        ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, {4, {dftUniqueBins, 1, 1, frameLength}});
-    auto imaginaryWeights = ctx->createNamedTempWeights(
-        ::ONNX_NAMESPACE::TensorProto_DataType_FLOAT, {4, {dftUniqueBins, 1, 1, frameLength}});
+    auto realWeights = ctx->createNamedTempWeights(onnxWeightType, {4, {dftUniqueBins, 1, 1, frameLength}});
+    auto imaginaryWeights = ctx->createNamedTempWeights(onnxWeightType, {4, {dftUniqueBins, 1, 1, frameLength}});
 
-    for (int64_t w = 0; w < static_cast<int64_t>(dftUniqueBins); w++)
+    // Read the window in FP32 regardless of its storage type so FP16/BF16 window initializers decode correctly.
+    float const* window = ctx->getWeightsContext().getFP32Values(windowWeights);
+
+    if (!window)
     {
-        for (int64_t k = 0; k < static_cast<int64_t>(frameLength); k++)
-        {
-            int64_t weightIndex = w * frameLength + k;
-            auto angle = -2.F * M_PI * w * k / frameLength;
-            static_cast<float*>(realWeights.values)[weightIndex]
-                = static_cast<float>(cos(angle)) * static_cast<float*>(windowWeights.values)[k];
-            static_cast<float*>(imaginaryWeights.values)[weightIndex]
-                = static_cast<float>(sin(angle)) * static_cast<float*>(windowWeights.values)[k];
-        }
+        ONNXTRT_CHECK_NODE(false, "Failed to get window weights!", node, nodeIdx, ErrorCode::kINVALID_NODE);
+    }
+
+    // Fill the weights for the convolutions, of shape (dftUniqueBins, 1, 1, frameLength).
+    switch (inputType)
+    {
+    case nvinfer1::DataType::kHALF:
+    {
+        fillStftDftWeights<half_float::half>(realWeights, imaginaryWeights, window, dftUniqueBins, frameLength);
+        break;
+    }
+    case nvinfer1::DataType::kBF16:
+    {
+        fillStftDftWeights<BFloat16>(realWeights, imaginaryWeights, window, dftUniqueBins, frameLength);
+        break;
+    }
+    default:
+    {
+        fillStftDftWeights<float>(realWeights, imaginaryWeights, window, dftUniqueBins, frameLength);
+        break;
+    }
     }
 
     // Unsqueeze input to [batch, 1, 1, numFrames]
-    auto signalReshaped = unsqueezeTensor(ctx, *input, {1, 2});
+    auto signalReshaped = unsqueezeTensor(ctx, *input, std::array{int32_t{1}, int32_t{2}});
 
     // 1D Convolution to calculate the real part of the signal.
     auto convReal = N_CHECK(
@@ -7211,7 +7473,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Upsample)
     {
         // TRT-15340: Adapt to use resizeShapeTensor instead when safety support nbDims == 1.
         ONNXTRT_CHECK_NODE(
-            attrs.count("scales"), "Attribute scales is missing.", node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE_ATTR);
+            attrs.contains("scales"), "Attribute scales is missing.", node, nodeIdx, ErrorCode::kUNSUPPORTED_NODE_ATTR);
         // Get scale factors from OnnxAttrs.
         auto scales = attrs.get<std::vector<float>>("scales");
         // Scale factors has batch dimension.
@@ -7332,7 +7594,7 @@ std::vector<nvinfer1::PluginField> loadFields(StringMap<std::vector<uint8_t>>& f
     for (int32_t i = 0; i < fieldNames->nbFields; ++i)
     {
         // Some plugins may have default values for fields that map to optional attributes in an ONNX graph.
-        if (!attrs.count(fieldNames->fields[i].name))
+        if (!attrs.contains(fieldNames->fields[i].name))
         {
             LOG_WARNING("Attribute " << fieldNames->fields[i].name
                                      << " not found in plugin node! Ensure that the plugin creator has a default value "
@@ -7462,7 +7724,7 @@ NodeOutputs addPluginWithCreator(ImporterContext* ctx, ::ONNX_NAMESPACE::NodePro
     std::unordered_set<int32_t> shapeInputIdxsSet{};
     auto const nbInputs{static_cast<int32_t>(inputs.size())};
 
-    if (attrs.count("tensorrt_plugin_shape_input_indices"))
+    if (attrs.contains("tensorrt_plugin_shape_input_indices"))
     {
         if (creator->getInterfaceInfo().kind != "PLUGIN CREATOR_V1"sv)
         {
@@ -7510,7 +7772,7 @@ NodeOutputs addPluginWithCreator(ImporterContext* ctx, ::ONNX_NAMESPACE::NodePro
     {
         auto input = inputs[idx];
         auto pluginInputVec
-            = shapeInputIdxsSet.find(idx) != shapeInputIdxsSet.end() ? &pluginShapeInputs : &pluginInputs;
+            = shapeInputIdxsSet.contains(idx) ? &pluginShapeInputs : &pluginInputs;
         if (input.isNullTensor())
         {
             LOG_VERBOSE("Found unset input for " << pluginName << ".");
@@ -7923,7 +8185,7 @@ DEFINE_BUILTIN_OP_IMPORTER(TRT_Shuffle)
 
     if (inputs.size() == 1)
     {
-        if (attrs.count("reshape_dims"))
+        if (attrs.contains("reshape_dims"))
         {
             nvinfer1::Dims reshapeDims = attrs.get<nvinfer1::Dims>("reshape_dims");
             layer->setReshapeDimensions(reshapeDims);
@@ -8207,7 +8469,7 @@ DEFINE_BUILTIN_OP_IMPORTER(TRT_MoE)
     //   8: fcDownBiases (optional, null if not provided)
     //   9: fcDownActivationScale (optional, for quantization)
     // Attributes:
-    //   activation_type: int32_t (0 = kNONE, 1 = kSILU) [default: 1]
+    //   activation_type: int32_t (0 = kNONE, 1 = kSILU) [default: 0]
     //   quantization_mode: int32_t (0 = none, 1 = static, 2 = dynamic_dblq) [default: 0]
     //   quantization_dtype: int32_t (DataType value for quantization, e.g., kFP8, kFP4) [default: kFP8]
     //   quantization_block_shape: int32_t array [4] (block shape for quantization) [default: [1,1,-1,-1]]
@@ -8235,7 +8497,7 @@ DEFINE_BUILTIN_OP_IMPORTER(TRT_MoE)
 
     // Get activation type attribute
     OnnxAttrs attrs(node, ctx);
-    int32_t activationTypeInt = attrs.get<int32_t>("activation_type", 0); // Default to kSILU
+    int32_t activationTypeInt = attrs.get<int32_t>("activation_type", 0); // Default to kNONE
 
     // Validate activation type
     ONNXTRT_CHECK_NODE((activationTypeInt == 0 || activationTypeInt == 1),
@@ -8315,7 +8577,7 @@ DEFINE_BUILTIN_OP_IMPORTER(TRT_MoE)
     }
 
     // Handle SwiGLU parameters
-    if (attrs.count("swiglu_limit") || attrs.count("swiglu_alpha") || attrs.count("swiglu_beta"))
+    if (attrs.contains("swiglu_limit") || attrs.contains("swiglu_alpha") || attrs.contains("swiglu_beta"))
     {
         float swigluLimit = attrs.get<float>("swiglu_limit", std::numeric_limits<float>::infinity());
         float swigluAlpha = attrs.get<float>("swiglu_alpha", 1.0F);

--- a/onnx_tensorrt/__init__.py
+++ b/onnx_tensorrt/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 
 from . import backend
 
-__version__ = "11.1.0"
+__version__ = "11.2.0"

--- a/weightUtils.cpp
+++ b/weightUtils.cpp
@@ -157,7 +157,7 @@ std::string const& generateUniqueName(
 {
     std::string candidate = basename;
 
-    while (namesSet.find(candidate) != namesSet.end())
+    while (namesSet.contains(candidate))
     {
         candidate = basename + "_" + std::to_string(suffixCounter);
         ++suffixCounter;


### PR DESCRIPTION
- Added `IRefitterObserver` class for better refitting of ONNX models.
- Added support for the `DFT` operator and 5D `GridSample` operators.